### PR TITLE
Wallet: Use default provider when not enabled account

### DIFF
--- a/src/app-logic.js
+++ b/src/app-logic.js
@@ -13,7 +13,7 @@ export default function useAppLogic() {
   const { account } = useWallet()
 
   const { isLoading, stakeToken } = useAppState()
-  const [proposals] = useProposals()
+  const [proposals, blockHasLoaded] = useProposals()
   const proposalPanel = usePanelState()
 
   const { myStakes, totalActiveTokens } = useMemo(() => {
@@ -54,7 +54,7 @@ export default function useAppLogic() {
 
   return {
     actions,
-    isLoading: isLoading, // TODO: Add loading flag for block back again
+    isLoading: isLoading || !blockHasLoaded,
     myStakes,
     proposals,
     proposalPanel,

--- a/src/hooks/useOrgHooks.js
+++ b/src/hooks/useOrgHooks.js
@@ -72,7 +72,7 @@ export function useOrganzation() {
           },
         ],
         {
-          readProvider: ethers, // TODO: Remove once connect doesn't require a provider if it's not going to use it
+          readProvider: ethers,
           chainId: getDefaultChain(),
         }
       )

--- a/src/hooks/useOrgHooks.js
+++ b/src/hooks/useOrgHooks.js
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import gql from 'graphql-tag'
 import { GraphQLWrapper } from '@aragon/connect-thegraph'
-import { providers as EthersProviders } from 'ethers'
 
 import { ConvictionVoting } from '@1hive/connect-thegraph-conviction-voting'
 import { connect } from '@aragon/connect'
@@ -59,7 +58,7 @@ const DEFAULT_APP_DATA = {
 
 export function useOrganzation() {
   const [organzation, setOrganization] = useState(null)
-  const { ethereum } = useWallet()
+  const { ethers } = useWallet()
 
   useEffect(() => {
     let cancelled = false
@@ -73,9 +72,7 @@ export function useOrganzation() {
           },
         ],
         {
-          readProvider:
-            ethereum ||
-            new EthersProviders.JsonRpcProvider('https://xdai.poanetwork.dev/'), // TODO: Remove once connect doesn't require a provider if it's not going to use it
+          readProvider: ethers, // TODO: Remove once connect doesn't require a provider if it's not going to use it
           chainId: getDefaultChain(),
         }
       )
@@ -90,7 +87,7 @@ export function useOrganzation() {
     return () => {
       cancelled = true
     }
-  }, [ethereum])
+  }, [ethers])
 
   return organzation
 }

--- a/src/providers/Wallet.js
+++ b/src/providers/Wallet.js
@@ -18,7 +18,7 @@ function WalletAugmented({ children }) {
 
   const ethers = useMemo(() => {
     if (!ethereum) {
-      return null
+      return new EthersProviders.JsonRpcProvider(getNetwork().defaultEthNode)
     }
 
     const ensRegistry = getNetwork()?.ensRegistry


### PR DESCRIPTION
Defaults to use the `JsonProvider` when account is not enabled