### PR TITLE
Routing: Swap BrowserRouter for HashRouter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import { Main } from '@1hive/1hive-ui'
 
 import App from './App'
@@ -12,11 +12,11 @@ ReactDOM.render(
   <WalletProvider>
     <AppStateProvider>
       <Main assetsUrl="/aragon-ui/" layout={false}>
-        <BrowserRouter>
+        <HashRouter>
           <MainView>
             <App />
           </MainView>
-        </BrowserRouter>
+        </HashRouter>
       </Main>
     </AppStateProvider>
   </WalletProvider>,


### PR DESCRIPTION
The reason why we're doing this change is so that we can support direct links. The trick is the hash in the URL; as React apps get handled client-side and SSR is a whole other history, the HashRouter is best suited for it. The reason why this works is that the /#/ tells the server "ignore everything from the hash onwards; everything's gonna be handled client side". 

This [StackOverflow ](https://stackoverflow.com/questions/51974369/hashrouter-vs-browserrouter)question's really good at explaining this!