### PR TITLE
Account: Add 3box profile names

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "3box": "^1.21.0",
     "@1hive/1hive-ui": "^1.0.2",
     "@1hive/connect-thegraph-conviction-voting": "^0.1.7",
     "@1hive/uniswap-sdk": "^1.0.0",

--- a/src/components/Wallet.js
+++ b/src/components/Wallet.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   Box,
   EthIdenticon,
@@ -8,6 +8,7 @@ import {
   useTheme,
 } from '@1hive/1hive-ui'
 import styled from 'styled-components'
+import { getProfile } from '3box'
 import { useAppState } from '../providers/AppState'
 import { useWallet } from '../providers/Wallet'
 
@@ -16,11 +17,21 @@ import { formatTokenAmount, getTokenIconBySymbol } from '../lib/token-utils'
 import { useTokenBalanceToUsd } from '../hooks/useTokenPrice'
 
 function Wallet({ myStakes }) {
+  const [profileName, setProfileName] = useState(null)
   const theme = useTheme()
   const { account } = useWallet()
   const { accountBalance, stakeToken } = useAppState()
-
   const balanceUsdValue = useTokenBalanceToUsd(accountBalance, stakeToken)
+
+  useEffect(() => {
+    async function getProfileForAccount() {
+      if (account) {
+        const { name } = await getProfile(account)
+        setProfileName(name)
+      }
+    }
+    getProfileForAccount()
+  }, [account])
 
   const myActiveTokens = useMemo(() => {
     if (!myStakes) {
@@ -61,7 +72,7 @@ function Wallet({ myStakes }) {
             ${textStyle('title4')}
           `}
         >
-          {shortenAddress(account, 4)}
+          {profileName || shortenAddress(account, 4)}
         </span>
       </div>
       <div

--- a/src/components/Wallet.js
+++ b/src/components/Wallet.js
@@ -24,13 +24,22 @@ function Wallet({ myStakes }) {
   const balanceUsdValue = useTokenBalanceToUsd(accountBalance, stakeToken)
 
   useEffect(() => {
+    let cancelled = false
+
     async function getProfileForAccount() {
       if (account) {
         const { name } = await getProfile(account)
-        setProfileName(name)
+        if (!cancelled) {
+          setProfileName(name)
+        }
       }
     }
+
     getProfileForAccount()
+
+    return () => {
+      cancelled = true
+    }
   }, [account])
 
   const myActiveTokens = useMemo(() => {


### PR DESCRIPTION
Integrates 3Box profile names in a very minimal way, defaulting to the shortened address when an user doesn't have a profile. Later we could look into adding comments for every proposal, albeit this requires quite more code. :)

Screenshot from my fork of the repo:
<img width="753" alt="Screen Shot 2020-08-06 at 10 27 36 PM" src="https://user-images.githubusercontent.com/26014927/89602259-57228300-d834-11ea-84e5-0ad9ba94e79c.png">
