### PR TITLE
Fix BSOD due to supporters distribution component

### DIFF
--- a/src/components/SupportersDistribution.js
+++ b/src/components/SupportersDistribution.js
@@ -29,7 +29,7 @@ function displayedStakes(stakes, total, stakeToken) {
     item: {
       entity: stake.index === -1 ? 'Others' : stakes[stake.index].entity,
       amount: formatTokenAmount(
-        stakes[stake.index].amount,
+        stake.index === -1 ? 0 : stakes[stake.index].amount,
         stakeToken.decimals
       ),
     },


### PR DESCRIPTION
When we do not have space in the supporters distribution component and we need to have an "Others" line, the frontend crashes, and this patch is a fix to that issue.