### PR TITLE
Remove unused 2nd parameter on `executeProposal`

### DIFF
--- a/src/hooks/useActions.js
+++ b/src/hooks/useActions.js
@@ -77,7 +77,7 @@ export default function useActions(onDone) {
         organization,
         convictionVoting.address,
         'executeProposal',
-        [proposalId, true],
+        [proposalId],
         { ethers, from: account }
       )
 


### PR DESCRIPTION
It seems like an extra parameter to `executeProposal` was mistakenly added which currently makes it impossible to execute proposals from the Honey Pot interface.

As noted [here](https://github.com/1Hive/conviction-voting-app/blob/master/contracts/ConvictionVoting.sol#L214) the `executeProposal` method on the CV contract only takes 1 parameter.

**Error**

```
Could not create tx: Error: types/values length mismatch (count={"types":1,"values":2}, value={"types":[{"name":"_proposalId","type":"uint256","indexed":null,"components":null,"arrayLength":null,"arrayChildren":null,"baseType":"uint256","_isParamType":true}],"values":["3",true]}, code=INVALID_ARGUMENT, version=abi/5.0.2)
    makeError ethers.umd.js:3659
    throwError ethers.umd.js:3668
    encode ethers.umd.js:8159
    _encodeParams ethers.umd.js:8502
    encodeFunctionData ethers.umd.js:8525
    n transactions.ts:46
    o transactions.ts:89
    c calculatePath.ts:206
    paths TransactionIntent.ts:47
```