### PR TITLE
Link to Discord instead of Keybase

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -51,8 +51,8 @@ export default function Footer({ compact }) {
             >
               Community
             </h5>
-            <Link href="https://keybase.io/team/1hive" external>
-              Keybase
+            <Link href="https://discord.gg/4fm7pgB" external>
+              Discord
             </Link>
             <Link href="https://github.com/1Hive" external>
               Github


### PR DESCRIPTION
As per [this message](https://discordapp.com/channels/698287700834517064/708186850359246859/758053838862418001).