### PR TITLE
Search function improved for 1hive.org

### DIFF
--- a/src/lib/search-utils.js
+++ b/src/lib/search-utils.js
@@ -7,7 +7,7 @@ export function checkInitialLetters(text, searchTerm) {
   const str = text.substring(0, NUMBER_CHARACTERS)
 
   // Transform regex special characters into a '_' for easy reference.
-  searchTerm = searchTerm.replace(/[\*\[\(\)+\]]/g,' ');
+  searchTerm = searchTerm.replace(/[\*\[\(\)\\+\]]/g,' ');
   
   const pattern = searchTerm
     .split('')

--- a/src/lib/search-utils.js
+++ b/src/lib/search-utils.js
@@ -7,7 +7,7 @@ export function checkInitialLetters(text, searchTerm) {
   const str = text.substring(0, NUMBER_CHARACTERS)
 
   // Transform regex special characters into a '_' for easy reference.
-  searchTerm = searchTerm.replace(/[\*\[\(\)+\]]/g,'_');
+  searchTerm = searchTerm.replace(/[\*\[\(\)+\]]/g,' ');
   
   const pattern = searchTerm
     .split('')

--- a/src/lib/search-utils.js
+++ b/src/lib/search-utils.js
@@ -5,6 +5,10 @@ const NUMBER_CHARACTERS = 3
 */
 export function checkInitialLetters(text, searchTerm) {
   const str = text.substring(0, NUMBER_CHARACTERS)
+
+  // Transform regex special characters into a '_' for easy reference.
+  searchTerm = searchTerm.replace(/[\*\[\(\)+\]]/g,'_');
+  
   const pattern = searchTerm
     .split('')
     .map(char => `(?=.*${char})`)


### PR DESCRIPTION
The search function on 1hive.org was improved. This was in order to fix a bug that caused a client-side crash when entering special regex characters such as '*'.  Changes were tested, no conflicting errors.