### PR TITLE
Sort based on staked HNY

### DIFF
--- a/src/screens/Proposals.js
+++ b/src/screens/Proposals.js
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import React, { useCallback, useMemo, useState } from 'react'
 import {
   Box,
@@ -75,11 +76,29 @@ const Proposals = React.memo(
       ? [{ label: 'Request amount', align: 'start' }]
       : []
 
+    // TODO: This is technically not entirely correct
+    // as it does not sort based on conviction but the
+    // amount of staked HNY. There was no simple
+    // way to fetch the conviction for the proposals.
     const sortedProposals = useMemo(
       () =>
-        filteredProposals.sort(
-          (a, b) => b.currentConviction - a.currentConviction
-        ),
+        filteredProposals.sort((a, b) => {
+          const aStaked = a.stakes.reduce(
+            (sum, { amount }) => sum.plus(amount),
+            new BigNumber(0)
+          )
+          const bStaked = b.stakes.reduce(
+            (sum, { amount }) => sum.plus(amount),
+            new BigNumber(0)
+          )
+          if (bStaked.lt(aStaked)) {
+            return -1
+          } else if (bStaked.gt(aStaked)) {
+            return 1
+          }
+
+          return 0
+        }),
       [filteredProposals]
     )
 


### PR DESCRIPTION
During the proposal data refactor this part was missed: the proposals are no longer sorted correctly.

This fix is temporary since it does not sort on conviction (I could not figure out how to get the data in a simple manner), but on the amount of staked HNY.
