### PR TITLE
Sort proposals by current conviction

### DIFF
--- a/src/hooks/useProposals.js
+++ b/src/hooks/useProposals.js
@@ -18,7 +18,7 @@ import {
   getMinNeededStake,
   getRemainingTimeToPass,
 } from '../lib/conviction'
-import { testSupportFilter } from '../utils/filter-utils'
+import { sortProposals, testSupportFilter } from '../utils/filter-utils'
 import { getProposalSupportStatus } from '../lib/proposal-utils'
 
 const TIME_UNIT = (60 * 60 * 24) / 15
@@ -59,7 +59,9 @@ export function useProposals() {
     vaultBalance,
   ])
 
-  return [proposalsWithData, filters, latestBlock.number !== 0]
+  const sortedProposals = sortProposals(filters, proposalsWithData)
+
+  return [sortedProposals, filters, latestBlock.number !== 0]
 }
 
 function useFilteredProposals(filters, account) {

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -49,3 +49,15 @@ export function testSupportFilter(filter, proposalSupportStatus) {
       proposalSupportStatus === PROPOSAL_SUPPORT_NOT_SUPPORTED)
   )
 }
+
+export function sortProposals(filters, proposals) {
+  // When sorting by top we are sorting by lastConviction which is not entirely accurate
+  // as conviction on proposals can accrue at different speeds
+  if (filters.ranking.filter === RANKING_FILTER_TOP) {
+    return proposals.sort(
+      (p1, p2) => p2.currentConviction - p1.currentConviction
+    )
+  }
+
+  return proposals
+}


### PR DESCRIPTION
When sorting by`Top`, we are sorting from the subgraph by `lastConviction` which is not entirely accurate as conviction on proposals can accrue at different speeds.