### PR TITLE
Change support proposal input

### DIFF
--- a/src/components/panels/SupportProposalPanel.js
+++ b/src/components/panels/SupportProposalPanel.js
@@ -62,7 +62,7 @@ const SupportProposal = React.memo(function SupportProposal({
   // Amount change handler
   const handleAmountChange = useCallback(
     event => {
-      const newAmount = event.target.value
+      const newAmount = event.target.value.replace(/,/g, '.').replace(/-/g, '')
 
       const newAmountBN = new BigNumber(
         isNaN(event.target.value)


### PR DESCRIPTION
It has come to my attention, that negative numbers are allowed in the support proposal panel when supporting a proposal for the first time. I've made a simple regex that automatically replaces any '-' signs with '', which essentially removes any negative input. This is just a small change, for better design consistency. Also, I did so that typing, is valid as it replaces ',' with  '.' What do you guys think about this change? In my country for example some users are used to typing 3,2 instead of 3.2. Kind of odd actually. I thought by automatically replacing the comma with the dot, it would make their lives easier. Just another small detail.