### PR TITLE
Hotfix: Filter rejected and unexecutable votes from open

### DIFF
--- a/src/hooks/useProposals.js
+++ b/src/hooks/useProposals.js
@@ -19,7 +19,7 @@ import {
   getMinNeededStake,
   getRemainingTimeToPass,
 } from '../lib/conviction'
-import { testSupportFilter } from '../utils/filter-utils'
+import { testStatusFilter, testSupportFilter } from '../utils/filter-utils'
 import { getProposalSupportStatus } from '../lib/proposal-utils'
 import { getDecisionTransition } from '../lib/vote-utils'
 import { ProposalTypes } from '../types'
@@ -65,7 +65,16 @@ export function useProposals() {
     vaultBalance,
   ])
 
-  return [proposalsWithData, filters, latestBlock.number !== 0]
+  // Hotfix: TODO: Move to filtered proposals hook
+  const filteredProposals = proposalsWithData.filter(proposal => {
+    if (proposal.type === ProposalTypes.Decision) {
+      return testStatusFilter(filters.status.filter, proposal)
+    }
+
+    return true
+  })
+
+  return [filteredProposals, filters, latestBlock.number !== 0]
 }
 
 function useFilteredProposals(filters, account) {

--- a/src/utils/filter-utils.js
+++ b/src/utils/filter-utils.js
@@ -60,6 +60,14 @@ export function testSupportFilter(filter, proposalSupportStatus) {
   )
 }
 
+export function testStatusFilter(filter, proposal) {
+  return (
+    filter === NULL_FILTER_STATE ||
+    (filter === STATUS_FILTER_OPEN && proposal.data?.open) ||
+    (filter === STATUS_FILTER_CLOSED && proposal.data?.closed)
+  )
+}
+
 export function sortProposals(filters, proposals) {
   // When sorting by top we are sorting by lastConviction which is not entirely accurate
   // as conviction on proposals can accrue at different speeds


### PR DESCRIPTION
Filters already closed votes from Open status.

Closed but unexecuted or rejected Decisions, are technically still `Open` from the sugbraph.
This filter them locally when fetched. The problem is that they won't show up when filtering by `Closed`.
Will only be visible when selecting all status. 