### PR TITLE
Create Proposal->Founding->Warning box cutted off

### DIFF
--- a/src/components/panels/AddProposalPanel.js
+++ b/src/components/panels/AddProposalPanel.js
@@ -189,7 +189,12 @@ const AddProposalPanel = React.memo(({ onSubmit }) => {
     errors.length > 0
 
   return (
-    <form onSubmit={handleFormSubmit}>
+    <form
+      onSubmit={handleFormSubmit}
+      css={`
+        margin-bottom: ${7 * GU}px;
+      `}
+    >
       <Field
         label="Select proposal type"
         css={`
@@ -330,7 +335,6 @@ const AddProposalPanel = React.memo(({ onSubmit }) => {
           mode={neededThreshold ? 'info' : 'warning'}
           css={`
             margin-top: ${2 * GU}px;
-            margin-bottom: ${6 * GU}px;
           `}
         >
           {neededThreshold

--- a/src/components/panels/AddProposalPanel.js
+++ b/src/components/panels/AddProposalPanel.js
@@ -330,6 +330,7 @@ const AddProposalPanel = React.memo(({ onSubmit }) => {
           mode={neededThreshold ? 'info' : 'warning'}
           css={`
             margin-top: ${2 * GU}px;
+            margin-bottom: ${6 * GU}px;
           `}
         >
           {neededThreshold


### PR DESCRIPTION
When founding proposal was selected, the last box was cutted off as the image that I'm attaching. This is fixed on this PR.
<img width="1347" alt="Screen Shot 2020-10-22 at 12 08 56 AM" src="https://user-images.githubusercontent.com/1489405/96820311-15998100-13fc-11eb-9ba1-90d307112aaf.png">
