### PR TITLE
Withdraw stake

### DIFF
--- a/src/components/Profile/InactiveProposalsStake.js
+++ b/src/components/Profile/InactiveProposalsStake.js
@@ -54,6 +54,7 @@ const ProposalItem = ({
       css={`
         display: flex;
         align-items: center;
+        margin-bottom: ${1 * GU}px;
       `}
     >
       <div

--- a/src/components/Profile/InactiveProposalsStake.js
+++ b/src/components/Profile/InactiveProposalsStake.js
@@ -1,0 +1,109 @@
+import React, { useCallback } from 'react'
+import { useHistory } from 'react-router-dom'
+import { Box, GU, textStyle, useTheme, useViewport } from '@1hive/1hive-ui'
+import { useAppState } from '../../providers/AppState'
+
+import { formatTokenAmount } from '../../utils/token-utils'
+
+function InactiveProposaksStake({ myInactiveStakes }) {
+  const { below } = useViewport()
+  const compact = below('large')
+  const history = useHistory()
+  const { stakeToken } = useAppState()
+
+  const handleSelectProposal = useCallback(
+    id => {
+      history.push(`/proposal/${id}`)
+    },
+    [history]
+  )
+  return (
+    <Box heading="Inactive proposals stake" padding={3 * GU}>
+      {myInactiveStakes.map(stake => {
+        return (
+          <ProposalItem
+            compact={compact}
+            proposalId={stake.proposal.id}
+            proposalName={stake.proposal.metadata}
+            selectProposal={handleSelectProposal}
+            stakeToken={stakeToken}
+            amount={stake.amount}
+          />
+        )
+      })}
+    </Box>
+  )
+}
+
+const ProposalItem = ({
+  amount,
+  compact,
+  proposalId,
+  proposalName,
+  selectProposal,
+  stakeToken,
+}) => {
+  const theme = useTheme()
+
+  const handleOnClick = useCallback(() => {
+    selectProposal(proposalId)
+  }, [proposalId, selectProposal])
+
+  return (
+    <div
+      css={`
+        display: flex;
+        align-items: center;
+      `}
+    >
+      <div
+        css={`
+          width: ${1 * GU}px;
+          height: ${1 * GU}px;
+          border-radius: 50%;
+          background: ${theme.disabled};
+          margin-right: ${1 * GU}px;
+          flex-shrink: 0;
+        `}
+      />
+      <div
+        css={`
+          display: flex;
+          width: 100%;
+          justify-content: space-between;
+          align-items: center;
+          ${textStyle('body2')};
+        `}
+      >
+        <div
+          css={`
+            background: ${theme.badge};
+            border-radius: 3px;
+            padding: ${0.5 * GU}px ${1 * GU}px;
+            width: ${compact ? '100%' : `${18 * GU}px`};
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+
+            ${proposalId &&
+              `cursor: pointer; &:hover {
+            background: ${theme.badge.alpha(0.7)}
+          }`}
+          `}
+          onClick={proposalId ? handleOnClick : null}
+        >
+          {proposalName}
+        </div>
+        <span
+          css={`
+            margin-left: ${1 * GU}px;
+          `}
+        >
+          {formatTokenAmount(amount, stakeToken.decimals)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default InactiveProposaksStake

--- a/src/components/ProposalDetail/ProposalActions.js
+++ b/src/components/ProposalDetail/ProposalActions.js
@@ -28,7 +28,7 @@ function ProposalActions({
   const { stakeToken, accountBalance } = useAppState()
   const { account: connectedAccount } = useWallet()
 
-  const { id, currentConviction, stakes, threshold, status } = proposal
+  const { id, currentConviction, stakes, status, threshold } = proposal
   const totalStaked = useAccountTotalStaked(connectedAccount)
 
   const myStake = useMemo(

--- a/src/hooks/useProposals.js
+++ b/src/hooks/useProposals.js
@@ -7,6 +7,7 @@ import useProposalFilters from './useProposalFilters'
 import {
   useProposalSubscription,
   useProposalsSubscription,
+  useSupporterSubscription,
 } from './useSubscriptions'
 import { useWallet } from '../providers/Wallet'
 
@@ -23,6 +24,7 @@ import { testStatusFilter, testSupportFilter } from '../utils/filter-utils'
 import { getProposalSupportStatus } from '../utils/proposal-utils'
 import { getDecisionTransition } from '../utils/vote-utils'
 import { ProposalTypes } from '../types'
+import { PROPOSAL_STATUS_ACTIVE_STRING } from '../constants'
 
 const TIME_UNIT = (60 * 60 * 24) / 15
 
@@ -137,6 +139,26 @@ export function useProposal(proposalId, appAddress) {
         )
 
   return [proposalWithData, blockHasLoaded, loadingProposal]
+}
+
+export function useInactiveProposalsWithStake() {
+  const { account } = useWallet()
+  const { honeypot } = useAppState()
+
+  const supporter = useSupporterSubscription(honeypot, account)
+
+  if (!supporter || !supporter.stakes) {
+    return []
+  }
+  const inactiveStakes = supporter.stakes.filter(stake => {
+    return (
+      stake.proposal.type !== ProposalTypes.Decision &&
+      stake.proposal.status !== PROPOSAL_STATUS_ACTIVE_STRING &&
+      stake.amount.gt(0)
+    )
+  })
+
+  return inactiveStakes
 }
 
 function processProposal(

--- a/src/hooks/useProposals.js
+++ b/src/hooks/useProposals.js
@@ -24,7 +24,10 @@ import { testStatusFilter, testSupportFilter } from '../utils/filter-utils'
 import { getProposalSupportStatus } from '../utils/proposal-utils'
 import { getDecisionTransition } from '../utils/vote-utils'
 import { ProposalTypes } from '../types'
-import { PROPOSAL_STATUS_ACTIVE_STRING } from '../constants'
+import {
+  PROPOSAL_STATUS_CANCELLED_STRING,
+  PROPOSAL_STATUS_EXECUTED_STRING,
+} from '../constants'
 
 const TIME_UNIT = (60 * 60 * 24) / 15
 
@@ -153,7 +156,8 @@ export function useInactiveProposalsWithStake() {
   const inactiveStakes = supporter.stakes.filter(stake => {
     return (
       stake.proposal.type !== ProposalTypes.Decision &&
-      stake.proposal.status !== PROPOSAL_STATUS_ACTIVE_STRING &&
+      (stake.proposal.status === PROPOSAL_STATUS_CANCELLED_STRING ||
+        stake.proposal.status === PROPOSAL_STATUS_EXECUTED_STRING) &&
       stake.amount.gt(0)
     )
   })

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -5,6 +5,7 @@ import { animated, Spring } from 'react-spring/renderprops'
 
 import Activity from '../components/Profile/Activity'
 import EditProfile from '../components/Profile/EditProfile'
+import InactiveProposalsStake from '../components/Profile/InactiveProposalsStake'
 import Loader from '../components/Loader'
 import MainProfile from '../components/Profile/MainProfile'
 import StakingTokens from '../components/Profile/StakingTokens'
@@ -13,6 +14,7 @@ import Wallet from '../components/Wallet'
 import { useAccountStakes } from '../hooks/useStakes'
 import { useAppState } from '../providers/AppState'
 import usePicture from '../hooks/usePicture'
+import { useInactiveProposalsWithStake } from '../hooks/useProposals'
 import useSelectedProfile from '../hooks/useSelectedProfile'
 import { useWallet } from '../providers/Wallet'
 import { addressesEqual } from '../utils/web3-utils'
@@ -35,6 +37,7 @@ function Profile() {
   const searchParams = useSearchParams()
   const selectedAccount = searchParams.get('account') || connectedAccount
   const accountStakes = useAccountStakes(selectedAccount)
+  const accountInactiveStakes = useInactiveProposalsWithStake()
 
   const selectedProfile = useSelectedProfile(selectedAccount)
   const { coverPhoto } = selectedProfile || {}
@@ -147,6 +150,9 @@ function Profile() {
                             myStakes={accountStakes}
                           />
                           <StakingTokens myStakes={accountStakes} />
+                          <InactiveProposalsStake
+                            myInactiveStakes={accountInactiveStakes}
+                          />
                         </>
                       }
                       invert={oneColumn ? 'vertical' : 'horizontal'}

--- a/src/screens/ProposalDetail.js
+++ b/src/screens/ProposalDetail.js
@@ -251,17 +251,17 @@ function ProposalDetail({ match }) {
                         />
                       }
                     />
-                    <ProposalActions
-                      proposal={proposal}
-                      onExecuteProposal={convictionActions.executeProposal}
-                      onRequestSupportProposal={panelState.requestOpen}
-                      onStakeToProposal={convictionActions.stakeToProposal}
-                      onWithdrawFromProposal={
-                        convictionActions.withdrawFromProposal
-                      }
-                    />
                   </>
                 )}
+                <ProposalActions
+                  proposal={proposal}
+                  onExecuteProposal={convictionActions.executeProposal}
+                  onRequestSupportProposal={panelState.requestOpen}
+                  onStakeToProposal={convictionActions.stakeToProposal}
+                  onWithdrawFromProposal={
+                    convictionActions.withdrawFromProposal
+                  }
+                />
               </section>
             </Box>
           }


### PR DESCRIPTION
We noticed that given some concerns on the community about the abstain proposal stakes amounts that we were having some weird numbers on the active hny amounts, that is because we were not letting the user withdraw his stake from canceled or executed proposals.
At the beginning we were just relying on the ability of the smart contract to withdraw automatically from executed or canceled proposals the amount needed in case they want to support into another proposal but the reality is that if we don't give the chance to the user to withdraw it by themselves whenever they want is like we are forcing them to `Abstain` because those tokens staked on executed or cancelled proposals are taken into account as active because we are not automatically withdrawing in the smart contract for security reasons.

So a new component was added to the profile page where each user is going to be able to see in which proposals their have inactive stakes.