### PR TITLE
Modal state flow changes

### DIFF
--- a/src/components/Stepper/Step/Illustration.js
+++ b/src/components/Stepper/Step/Illustration.js
@@ -28,11 +28,10 @@ function Illustration({ status, index }) {
             display: flex;
             align-items: center;
             justify-content: center;
-            background-color: ${theme.surfaceOpened};
+            background-color: ${theme.surfaceIcon};
             height: 100%;
             width: 100%;
             border-radius: 100%;
-            color: ${theme.accentContent};
           `}
         />
       ) : (

--- a/src/components/Stepper/Step/Illustration.js
+++ b/src/components/Stepper/Step/Illustration.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTheme } from '@1hive/1hive-ui'
 import {
   STEP_ERROR,
   STEP_SUCCESS,
@@ -9,36 +10,34 @@ import {
 
 import signRequestSuccessIllustration from '../../../assets/signRequestSuccess.svg'
 import signRequestFailIllustration from '../../../assets/signRequestFail.svg'
-import signPrompIllustration from '../../../assets/honey.svg'
+import trxBeingMinedIllustration from '../../../assets/honey.svg'
 
 const illustrations = {
-  [STEP_PROMPTING]: signPrompIllustration,
-  [STEP_WORKING]: signRequestSuccessIllustration,
+  [STEP_WORKING]: trxBeingMinedIllustration,
   [STEP_SUCCESS]: signRequestSuccessIllustration,
   [STEP_ERROR]: signRequestFailIllustration,
 }
 
 function Illustration({ status, index }) {
+  const theme = useTheme()
   return (
     <>
-      {/* {status === STEP_WORKING ? (
+      {status === STEP_PROMPTING ? (
         <div
-          id="LOADER WRAPPER"
           css={`
             display: flex;
-            width: 100%;
-            height: 100%;
-            flex-direction: column;
             align-items: center;
+            justify-content: center;
+            background-color: ${theme.surfaceOpened};
+            height: 100%;
+            width: 100%;
+            border-radius: 100%;
+            color: ${theme.accentContent};
           `}
-        >
-          <TokenLoader />
-        </div>
-      ) : ( */}
-
-      <img src={illustrations[status]} height={70} width={70} />
-
-      {/* )} */}
+        />
+      ) : (
+        <img src={illustrations[status]} height={70} width={70} />
+      )}
     </>
   )
 }

--- a/src/components/Stepper/Step/Illustration.js
+++ b/src/components/Stepper/Step/Illustration.js
@@ -35,7 +35,7 @@ function Illustration({ status, index }) {
           `}
         />
       ) : (
-        <img src={illustrations[status]} height={70} width={70} />
+        <img src={illustrations[status]} height={96} width={96} />
       )}
     </>
   )

--- a/src/components/Stepper/Step/StatusVisual.js
+++ b/src/components/Stepper/Step/StatusVisual.js
@@ -208,11 +208,11 @@ function StepIllustration({ number, status, withoutFirstStep }) {
             display: flex;
             align-items: center;
             justify-content: center;
-            background-color: ${theme.surfaceOpened};
+            background-color: ${theme.surfaceIcon};
             height: 100%;
             width: 100%;
             border-radius: 100%;
-            color: ${theme.accentContent};
+            color: ${theme.positiveContent};
 
             ${textStyle('title3')}
             font-weight: 600;

--- a/src/components/Stepper/Step/StatusVisual.js
+++ b/src/components/Stepper/Step/StatusVisual.js
@@ -192,7 +192,6 @@ function StepIllustration({ number, status, withoutFirstStep }) {
 
   return (
     <div
-      id="illustration div!!!!!"
       css={`
         display: flex;
         justify-content: center;

--- a/src/components/Stepper/Step/StatusVisual.js
+++ b/src/components/Stepper/Step/StatusVisual.js
@@ -68,8 +68,8 @@ function StatusVisual({ status, color, number, withoutFirstStep, ...props }) {
       css={`
         display: flex;
         position: relative;
-        width: ${13.5 * GU}px;
-        height: ${13.5 * GU}px;
+        width: ${15 * GU}px;
+        height: ${15 * GU}px;
       `}
       {...props}
     >

--- a/src/components/Stepper/Step/StatusVisual.js
+++ b/src/components/Stepper/Step/StatusVisual.js
@@ -214,7 +214,7 @@ function StepIllustration({ number, status, withoutFirstStep }) {
             border-radius: 100%;
             color: ${theme.positiveContent};
 
-            ${textStyle('title3')}
+            ${textStyle('title3')};
             font-weight: 600;
           `}
         >

--- a/src/components/Stepper/Step/Step.js
+++ b/src/components/Stepper/Step/Step.js
@@ -49,8 +49,8 @@ function Step({
         descColor: theme.contentSecondary,
       },
       [STEP_WORKING]: {
-        visualColor: theme.accent,
-        descColor: theme.accent,
+        visualColor: '#FFE862',
+        descColor: '#C3A22B',
       },
       [STEP_SUCCESS]: {
         visualColor: theme.positive,
@@ -196,26 +196,7 @@ function Step({
                     networkType={network.legacyNetworkType}
                   />
                 </AnimatedSpan>
-              ) : (
-                <></>
-                // <AnimatedSpan
-                //   style={transitionProps}
-                //   css={`
-                //     display: flex;
-                //     justify-content: center;
-                //     width: 100%;
-                //   `}
-                // >
-                //   <div
-                //     css={`
-                //       height: ${3 * GU}px;
-                //       width: ${15 * GU}px;
-                //       border-radius: ${RADIUS}px;
-                //       border: 1px dashed ${theme.border};
-                //     `}
-                //   />
-                // </AnimatedSpan>
-              )}
+              ) : null}
           </Transition>
         </div>
 

--- a/src/components/Stepper/Stepper.js
+++ b/src/components/Stepper/Stepper.js
@@ -86,11 +86,12 @@ function Stepper({ steps, onComplete, ...props }) {
 
   const renderSteps = useCallback(() => {
     return steps.map((_, index) => {
-      const showDivider = index < stepsCount
+      const showDivider =
+        index < stepsCount && stepState[index].status !== STEP_WAITING
 
       return renderStep(index, showDivider)
     })
-  }, [steps, stepsCount, renderStep])
+  }, [renderStep, steps, stepsCount, stepState])
 
   const updateStepStatus = useCallback(
     status => {

--- a/src/components/Stepper/stepper-descriptions.js
+++ b/src/components/Stepper/stepper-descriptions.js
@@ -9,8 +9,8 @@ import {
 export const TRANSACTION_SIGNING_DESC = {
   [STEP_WAITING]: 'Waiting for signature',
   [STEP_PROMPTING]: 'Waiting for signature',
-  [STEP_WORKING]: 'Transaction being mined',
-  [STEP_SUCCESS]: 'Transaction mined',
+  [STEP_WORKING]: 'Transaction is being mined',
+  [STEP_SUCCESS]: 'Transaction successfully mined',
   [STEP_ERROR]: 'An error has occured',
 }
 

--- a/src/networks.js
+++ b/src/networks.js
@@ -18,7 +18,8 @@ const networks = {
     ensRegistry: '0x98df287b6c145399aaa709692c8d308357bc085d',
     name: 'Rinkeby',
     type: 'rinkeby',
-    defaultEthNode: 'https://rinkeby.eth.aragon.network/',
+    defaultEthNode:
+      'https://rinkeby.infura.io/v3/99641171cb854b84b508ebeb4b094a2f',
     honeypot: getRinkebyHoneyPotAddress(INSTANCE),
     arbitrator: '0x35e7433141D5f7f2EB7081186f5284dCDD2ccacE',
     disputeManager: '0xc1f1c30878de30fd3ac3db7eacdd33a70c7110bd',


### PR DESCRIPTION
This PR address this suggestion

We should add a third step to the modal for the user to allow the 1Hive protocol

We need to make some color adjustments to differentiate more the states of "Transaction is being minded..." and "Transaction successfully mined", here you can see the differentiation. Not only the icon changes, the color of the arrow too, they should be yellow when the transaction is being minded. The text should change the color too

The "Transaction being minded" changes to "Transaction is being minded..."

The "Transaction mined" text changes to "Transaction successfully mined"

The Waiting for signature step indicator, should change the grey to our grey, now it has the Aragon's one

**from #336** 