### PR TITLE
Expandable card: Fix border bottom radius

### DIFF
--- a/src/components/Stake/ExpandableCard.js
+++ b/src/components/Stake/ExpandableCard.js
@@ -142,7 +142,7 @@ function OpenedSurfaceBorder({ opened }) {
             right: 0;
             bottom: 0;
             overflow: hidden;
-            border-radius: ${BIG_RADIUS}px;
+            border-top-left-radius: ${BIG_RADIUS}px;
           `}
         >
           <AnimatedDiv


### PR DESCRIPTION
Since the expandable component uses a border bottom radius of 0 we should adapt the highlighted border accordingly

**Before**
![Screen Shot 2021-04-10 at 17 17 18](https://user-images.githubusercontent.com/22663232/114283558-bb7b8f00-9a20-11eb-960f-a32aea21210f.png)


**After**
![Screen Shot 2021-04-10 at 17 16 56](https://user-images.githubusercontent.com/22663232/114283557-ba4a6200-9a20-11eb-897f-0363ba2299cf.png)
