### PR TITLE
Fix honey-pot loading artifacts data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "3box": "^1.22.2",
     "@1hive/1hive-ui": "^1.0.6",
     "@1hive/connect-disputable-honey-pot": "^0.2.0",
-    "@1hive/connect-react": "^0.8.5",
+    "@1hive/connect-react": "^0.8.6",
     "@aragon/connect-agreement": "^0.0.0-beta.14",
     "@juggle/resize-observer": "^3.2.0",
     "bignumber.js": "^9.0.0",

--- a/src/providers/Connect.js
+++ b/src/providers/Connect.js
@@ -13,6 +13,7 @@ function ConnectProvider({ children }) {
       connector="thegraph"
       options={{
         network: getDefaultChain(),
+        ipfs: 'https://ipfs.io/ipfs/{cid}{path}',
       }}
     >
       {children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,10 +149,10 @@
   dependencies:
     "@1hive/connect-core" "^0.8.5"
 
-"@1hive/connect-react@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@1hive/connect-react/-/connect-react-0.8.5.tgz#dabed19cbad825ee76e004cb0d8e41c354b45ae9"
-  integrity sha512-KF5YymR8v1+aAPgse5+FM4pBIMxQQ45kSGbzRlC1vOd7whjYEyDEc9TpBFyWXO2MDoxLUWlNaETN8SHuk3v7RA==
+"@1hive/connect-react@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@1hive/connect-react/-/connect-react-0.8.6.tgz#aa74a98684106aff2853e3b5b8ed26553be63516"
+  integrity sha512-2xXThtkLYbDq2qfhiubYXIbnD+0Fa8aMg31HGD7GwhXiqtRTVp1Dx1SdDNcbJTqWvCYRtpYpEsJYBuEj6IPR1Q==
   dependencies:
     "@1hive/connect" "^0.8.5"
 


### PR DESCRIPTION
- Update connect version
- Override the default `ipfs` resolver used by Connect for `ipfs.io`