### PR TITLE
Use updated gardens connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "3box": "^1.19.1",
     "@1hive/1hive-ui": "^1.0.10",
-    "@1hive/connect-gardens": "0.0.5",
+    "@1hive/connect-gardens": "^0.1.0",
     "@1hive/connect-react": "^0.8.6",
     "@1hive/gardens-dao-list": "^1.0.4",
     "@aragon/connect-agreement": "^0.0.0-beta.14",

--- a/src/components/GardensDashboard.js
+++ b/src/components/GardensDashboard.js
@@ -115,7 +115,7 @@ function GardenCard({ garden }) {
           {garden.proposalCount} Proposal{garden.proposalCount === 1 ? '' : 's'}
         </div>
         <div>
-          {garden.membersCount} Member{garden.membersCount === 1 ? '' : 's'}
+          {garden.supporterCount} Member{garden.supporterCount === 1 ? '' : 's'}
         </div>
       </div>
     </div>

--- a/src/providers/Gardens.js
+++ b/src/providers/Gardens.js
@@ -53,7 +53,10 @@ function useGardensList() {
   useEffect(() => {
     const fetchGardens = async () => {
       try {
-        const result = await getGardens({ network: getNetwork().chainId }, {})
+        const result = await getGardens(
+          { network: getNetwork().chainId },
+          { orderBy: 'honeyLiquidity' }
+        )
         setGardens(result)
       } catch (err) {
         console.error(`Error fetching daos ${err}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,10 @@
   dependencies:
     "@1hive/connect-core" "^0.8.5"
 
-"@1hive/connect-gardens@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@1hive/connect-gardens/-/connect-gardens-0.0.5.tgz#abd999fcb22bc64ed923cfa4a16b44fc8e5ef1fa"
-  integrity sha512-zXbb/MKUUNENVVfK0vRzN9toga3IGFtiV7enRvAjAIar2VgFwjeeOkE3bU+0HOhWWjItk+h6FSwhB1UPViWUCg==
+"@1hive/connect-gardens@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@1hive/connect-gardens/-/connect-gardens-0.1.0.tgz#57db53203b251e9804b3004d76bda08547d7965f"
+  integrity sha512-yv43Xh4v6reVdkSiQO5Dkhc25RKZdE2nssE9+5dljWdijKGpDGns4/fwFECkvw1l0tpZfuHjPpmRyqvqRP+8zA==
   dependencies:
     "@aragon/connect-core" "0.7.0"
     "@aragon/connect-thegraph" "0.7.0"


### PR DESCRIPTION
- Uses new `supporterCount` attribute
- Sorts gardens by `honeyLiquidity`