### PR TITLE
Fixes

### DIFF
--- a/src/components/Garden/ActionCollateral.js
+++ b/src/components/Garden/ActionCollateral.js
@@ -7,6 +7,8 @@ import lockIconSvg from '@assets/icon-lock.svg'
 
 function ActionCollateral({ proposal }) {
   const { collateralRequirement } = proposal
+  const tokenIcon = getTokenIconBySymbol(collateralRequirement.tokenSymbol)
+
   return (
     <div
       css={`
@@ -15,7 +17,7 @@ function ActionCollateral({ proposal }) {
       `}
     >
       <img
-        src={getTokenIconBySymbol(collateralRequirement.tokenSymbol)} // TODO: Use deefault-token-list
+        src={tokenIcon} // TODO: Use deefault-token-list
         alt=""
         height="24"
         width="24"

--- a/src/components/Garden/ActionCollateral.js
+++ b/src/components/Garden/ActionCollateral.js
@@ -15,7 +15,7 @@ function ActionCollateral({ proposal }) {
       `}
     >
       <img
-        src={getTokenIconBySymbol(collateralRequirement.tokenSymbol)}
+        src={getTokenIconBySymbol(collateralRequirement.tokenSymbol)} // TODO: Use deefault-token-list
         alt=""
         height="24"
         width="24"

--- a/src/components/Garden/ActionCollateral.js
+++ b/src/components/Garden/ActionCollateral.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { GU } from '@1hive/1hive-ui'
 
 import { formatTokenAmount } from '@utils/token-utils'
-import honeyIconSvg from '@assets/honey.svg'
+import { getTokenIconBySymbol } from '../../utils/token-utils'
 import lockIconSvg from '@assets/icon-lock.svg'
 
 function ActionCollateral({ proposal }) {
@@ -15,12 +15,12 @@ function ActionCollateral({ proposal }) {
       `}
     >
       <img
-        src={honeyIconSvg}
+        src={getTokenIconBySymbol(collateralRequirement.tokenSymbol)}
         alt=""
-        height="28"
-        width="28"
+        height="24"
+        width="24"
         css={`
-          margin-right: ${0.5 * GU}px;
+          margin-right: ${1 * GU}px;
         `}
       />
       <div

--- a/src/components/Garden/ConvictionVisuals.js
+++ b/src/components/Garden/ConvictionVisuals.js
@@ -128,10 +128,8 @@ export function ConvictionBar({ proposal, withThreshold = true }) {
 }
 
 export function ConvictionCountdown({ proposal, shorter }) {
-  const {
-    maxRatio,
-    stakeToken: { symbol, decimals },
-  } = useGardenState()
+  const { config, maxRatio } = useGardenState()
+  const { stakeToken } = config.conviction
 
   const theme = useTheme()
 
@@ -190,7 +188,10 @@ export function ConvictionCountdown({ proposal, shorter }) {
                   <React.Fragment>
                     At least{' '}
                     <Tag>
-                      {`${formatTokenAmount(neededTokens, decimals)} ${symbol}`}
+                      {`${formatTokenAmount(
+                        neededTokens,
+                        stakeToken.decimals
+                      )} ${stakeToken.symbol}`}
                     </Tag>{' '}
                     more needed
                   </React.Fragment>

--- a/src/components/Garden/DecisionDetail/DecisionDetail.js
+++ b/src/components/Garden/DecisionDetail/DecisionDetail.js
@@ -303,7 +303,7 @@ function DecisionDetail({ proposal, actions }) {
             agreementActions={{
               challengeAction: actions.challengeAction,
               getAllowance: actions.getAllowance,
-              approveChallengeTokenAmount: actions.approveChallengeTokenAmount,
+              approveTokenAmount: actions.approveTokenAmount,
             }}
             proposal={proposal}
           />

--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -45,13 +45,6 @@ const Home = React.memo(function Home() {
     setFilterSidlerVisible(visible => !visible)
   }, [])
 
-  useEffect(() => {
-    // Components that redirect to create a proposal will do so through "garden/${gardenId}/create" url
-    if (account && history.location.pathname.includes('create')) {
-      setModalVisible(true)
-    }
-  }, [account, history])
-
   const handleShowModal = useCallback(mode => {
     setModalVisible(true)
     setModalMode(mode)
@@ -76,6 +69,15 @@ const Home = React.memo(function Home() {
   const handleUnwrapToken = useCallback(() => {
     handleShowModal('unwrap')
   }, [handleShowModal])
+
+  useEffect(() => {
+    console.log('running')
+    // Components that redirect to create a proposal will do so through "garden/${gardenId}/create" url
+    if (account && history.location.pathname.includes('create')) {
+      console.log('entered')
+      handleRequestNewProposal()
+    }
+  }, [account, handleRequestNewProposal, history])
 
   // TODO: Refactor components positioning with a grid layout
   return (

--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -71,10 +71,8 @@ const Home = React.memo(function Home() {
   }, [handleShowModal])
 
   useEffect(() => {
-    console.log('running')
     // Components that redirect to create a proposal will do so through "garden/${gardenId}/create" url
     if (account && history.location.pathname.includes('create')) {
-      console.log('entered')
       handleRequestNewProposal()
     }
   }, [account, handleRequestNewProposal, history])

--- a/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeProposalScreens.js
+++ b/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeProposalScreens.js
@@ -13,7 +13,7 @@ const ZERO_BN = new BigNumber(toDecimals('0', 18))
 function ChallengeProposalScreens({ agreementActions, proposal }) {
   const [transactions, setTransactions] = useState([])
   const [agreement, loading] = useAgreement()
-  const { token } = useGardenState()
+  const { token, wrappableToken } = useGardenState()
   const disputeFees = useDisputeFees()
 
   const temporatyTrx = useRef([])
@@ -81,7 +81,7 @@ function ChallengeProposalScreens({ agreementActions, proposal }) {
         content: (
           <ChallengeRequirements
             agreement={agreement}
-            accountBalance={token.accountBalance}
+            accountBalance={(wrappableToken || token).accountBalance}
             disputeFees={disputeFees}
           />
         ),
@@ -103,7 +103,8 @@ function ChallengeProposalScreens({ agreementActions, proposal }) {
       disputeFees,
       getTransactions,
       proposal,
-      token.accountBalance,
+      token,
+      wrappableToken,
     ]
   )
 

--- a/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeProposalScreens.js
+++ b/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeProposalScreens.js
@@ -93,7 +93,9 @@ function ChallengeProposalScreens({ agreementActions, proposal }) {
         content: (
           <ChallengeRequirements
             agreement={agreement}
-            accountBalance={(wrappableToken || token).accountBalance}
+            collateralTokenAccountBalance={
+              (wrappableToken || token).accountBalance
+            }
             disputeFees={disputeFees}
           />
         ),

--- a/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeProposalScreens.js
+++ b/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeProposalScreens.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { addressesEqual } from '@1hive/1hive-ui'
 import ModalFlowBase from '../ModalFlowBase'
 import ChallengeRequirements from './ChallengeRequirements'
 import ChallengeForm from './ChallengeForm'
@@ -7,7 +8,6 @@ import { useDisputeFees } from '@hooks/useDispute'
 import { useAgreement } from '@hooks/useAgreement'
 import BigNumber from '@lib/bigNumber'
 import { toDecimals } from '@utils/math-utils'
-import { addressesEqual } from '@1hive/connect-core'
 
 const ZERO_BN = new BigNumber(toDecimals('0', 18))
 
@@ -16,6 +16,8 @@ function ChallengeProposalScreens({ agreementActions, proposal }) {
   const [agreement, loading] = useAgreement()
   const { token, wrappableToken } = useGardenState()
   const disputeFees = useDisputeFees()
+
+  const collateralToken = wrappableToken || token
 
   const temporatyTrx = useRef([])
 
@@ -54,9 +56,7 @@ function ChallengeProposalScreens({ agreementActions, proposal }) {
     ) => {
       const collateralToken = proposal.collateralRequirement.tokenId
       const collateralAmount = proposal.collateralRequirement.challengeAmount
-
-      const disputeFeeToken = disputeFees.token
-      const disputeFeeAmount = disputeFees.amount
+      const { amount: disputeFeeAmount, token: disputeFeeToken } = disputeFees
 
       // If collateral token is the same as the dispute fees token, approve once the added amount
       if (addressesEqual(collateralToken, disputeFeeToken)) {
@@ -93,9 +93,7 @@ function ChallengeProposalScreens({ agreementActions, proposal }) {
         content: (
           <ChallengeRequirements
             agreement={agreement}
-            collateralTokenAccountBalance={
-              (wrappableToken || token).accountBalance
-            }
+            collateralTokenAccountBalance={collateralToken.accountBalance}
             disputeFees={disputeFees}
           />
         ),
@@ -114,11 +112,10 @@ function ChallengeProposalScreens({ agreementActions, proposal }) {
     [
       agreement,
       agreementActions,
+      collateralToken,
       disputeFees,
       getTransactions,
       proposal,
-      token,
-      wrappableToken,
     ]
   )
 

--- a/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeRequirements.js
+++ b/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeRequirements.js
@@ -25,9 +25,6 @@ function ChallengeProposalRequirements({
     env('CONVICTION_APP_NAME')
   )
   const { challengeAmount, token } = convictionAppRequirements
-
-  const disputeFeesBN = new BigNumber(disputeFees.amount.toString())
-
   const enoughChallengeCollateral = accountBalance.gte(challengeAmount)
 
   const error = useMemo(() => {
@@ -55,12 +52,12 @@ function ChallengeProposalRequirements({
           margin-top: ${5 * GU}px;
         `}
       >
-        You must deposit {formatTokenAmount(disputeFeesBN, 18)} {token.symbol}{' '}
-        as the dispute fees.
+        You must deposit {formatTokenAmount(disputeFees.amount, 18)}{' '}
+        {token.symbol} as the dispute fees.
       </InfoField>
       <FeesStatus
         accountBalance={accountBalance}
-        feesAmount={disputeFeesBN}
+        feesAmount={disputeFees.amount}
         token={token}
       />
       <ModalButton

--- a/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeRequirements.js
+++ b/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeRequirements.js
@@ -4,7 +4,6 @@ import InfoField from '../../InfoField'
 import ModalButton from '../ModalButton'
 import { useMultiModal } from '@components/MultiModal/MultiModalProvider'
 
-import BigNumber from '@lib/bigNumber'
 import env from '@/environment'
 import { formatTokenAmount } from '@utils/token-utils'
 import { getDisputableAppByName } from '@utils/app-utils'

--- a/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeRequirements.js
+++ b/src/components/Garden/ModalFlows/ChallengeProposalScreens/ChallengeRequirements.js
@@ -11,11 +11,7 @@ import { getDisputableAppByName } from '@utils/app-utils'
 import iconError from '@assets/iconError.svg'
 import iconCheck from '@assets/iconCheck.svg'
 
-function ChallengeProposalRequirements({
-  agreement,
-  accountBalance,
-  disputeFees,
-}) {
+function ChallengeRequirements({ agreement, accountBalance, disputeFees }) {
   const { next } = useMultiModal()
   const { disputableAppsWithRequirements } = agreement
 
@@ -188,4 +184,4 @@ function InfoBox({ data }) {
   )
 }
 
-export default ChallengeProposalRequirements
+export default ChallengeRequirements

--- a/src/components/Garden/ModalFlows/CreateProposalScreens/CreateProposalRequirements.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/CreateProposalRequirements.js
@@ -158,7 +158,7 @@ function CollateralStatus({ allowance, availableStaked, actionAmount, token }) {
         backgroundColor: theme.negativeSurface.toString(),
         color: theme.negative,
         icon: iconError,
-        text: `You need to allow the Covenant as the lock manager of your staked HNY`,
+        text: `You need to allow the Covenant as the lock manager of your staked ${token.symbol}`,
         actionButton: 'Collateral manager',
         buttonOnClick: goToStakeManager,
       }

--- a/src/components/Garden/ModalFlows/RaiseDisputeScreens/RaiseDisputeScreens.js
+++ b/src/components/Garden/ModalFlows/RaiseDisputeScreens/RaiseDisputeScreens.js
@@ -20,32 +20,34 @@ function RaiseDisputeScreens({ proposal }) {
 
   const temporatyTrx = useRef([])
 
-  const disputeBN = useMemo(() => {
-    if (disputeFees.loading) {
-      return
-    }
-    return new BigNumber(disputeFees.amount.toString())
-  }, [disputeFees])
-
-  const getTransactions = useCallback(
-    async onComplete => {
-      const allowance = await agreementActions.getAllowance()
-      if (allowance.lt(disputeBN)) {
-        if (!allowance.eq(0)) {
-          await agreementActions.approveChallengeTokenAmount(
+  const approveTokenAmount = useCallback(
+    async (tokenAddress, amount) => {
+      const tokenAllowance = await agreementActions.getAllowance(tokenAddress)
+      if (tokenAllowance.lt(amount)) {
+        if (!tokenAllowance.eq(0)) {
+          await agreementActions.approveTokenAmount(
+            tokenAddress,
             ZERO_BN,
             intent => {
               temporatyTrx.current = temporatyTrx.current.concat(intent)
             }
           )
         }
-        await agreementActions.approveChallengeTokenAmount(
-          disputeBN.toString(),
+        await agreementActions.approveTokenAmount(
+          tokenAddress,
+          amount,
           intent => {
             temporatyTrx.current = temporatyTrx.current.concat(intent)
           }
         )
       }
+    },
+    [agreementActions]
+  )
+
+  const getTransactions = useCallback(
+    async onComplete => {
+      await approveTokenAmount(disputeFees.token, disputeFees.amount)
 
       await agreementActions.disputeAction(
         { actionId: proposal.actionId, submitterFinishedEvidence: true },
@@ -56,7 +58,7 @@ function RaiseDisputeScreens({ proposal }) {
         }
       )
     },
-    [proposal, agreementActions, disputeBN]
+    [agreementActions, approveTokenAmount, disputeFees, proposal]
   )
 
   const screens = useMemo(

--- a/src/components/Garden/ModalFlows/RaiseDisputeScreens/RaiseDisputeScreens.js
+++ b/src/components/Garden/ModalFlows/RaiseDisputeScreens/RaiseDisputeScreens.js
@@ -4,16 +4,14 @@ import ModalFlowBase from '../ModalFlowBase'
 import RaiseDisputeRequirements from './RaiseDisputeRequirements'
 
 import useActions from '@hooks/useActions'
-import { useGardenState } from '@providers/GardenState'
-import { useDisputeFees } from '@hooks/useDispute'
 import { useCelesteSynced } from '@hooks/useCeleste'
+import { useDisputeFees } from '@hooks/useDispute'
 import BigNumber from '@lib/bigNumber'
 
 const ZERO_BN = new BigNumber('0')
 
 function RaiseDisputeScreens({ proposal }) {
   const [transactions, setTransactions] = useState([])
-  const { token } = useGardenState()
   const [celesteSynced, celesteSyncLoading] = useCelesteSynced()
   const disputeFees = useDisputeFees()
   const { agreementActions } = useActions()
@@ -67,7 +65,6 @@ function RaiseDisputeScreens({ proposal }) {
         title: 'Raise dispute to Celeste',
         content: (
           <RaiseDisputeRequirements
-            accountBalance={token.accountBalance}
             celesteSynced={celesteSynced}
             disputeFees={disputeFees}
             getTransactions={getTransactions}
@@ -75,7 +72,7 @@ function RaiseDisputeScreens({ proposal }) {
         ),
       },
     ],
-    [celesteSynced, disputeFees, getTransactions, token.accountBalance]
+    [celesteSynced, disputeFees, getTransactions]
   )
 
   return (

--- a/src/components/Garden/ModalFlows/WrapTokenScreens/WrapUnwrap.js
+++ b/src/components/Garden/ModalFlows/WrapTokenScreens/WrapUnwrap.js
@@ -171,7 +171,7 @@ const WrapUnwrap = React.memo(function WrapUnwrap({ mode, getTransactions }) {
               wrappableToken.accountBalance,
               wrappableToken.data.decimals
             )}
-            {wrappableToken.symbol}
+            {wrappableToken.data.symbol}
           </span>
           {' and '}
           <span
@@ -180,7 +180,7 @@ const WrapUnwrap = React.memo(function WrapUnwrap({ mode, getTransactions }) {
             `}
           >
             {formatTokenAmount(token.accountBalance, token.data.decimals)}
-            {token.symbol}
+            {token.data.symbol}
           </span>
         </span>
       </Field>

--- a/src/components/Garden/ProposalDetail/ProposalDetail.js
+++ b/src/components/Garden/ProposalDetail/ProposalDetail.js
@@ -368,7 +368,7 @@ function ProposalDetail({
             agreementActions={{
               challengeAction: actions.challengeAction,
               getAllowance: actions.getAllowance,
-              approveChallengeTokenAmount: actions.approveChallengeTokenAmount,
+              approveTokenAmount: actions.approveTokenAmount,
             }}
             proposal={proposal}
           />

--- a/src/components/Garden/Stake/BalanceCard.js
+++ b/src/components/Garden/Stake/BalanceCard.js
@@ -9,8 +9,7 @@ import {
   useTheme,
 } from '@1hive/1hive-ui'
 import { useHoneyswapTokenPrice } from '@hooks/useHoneyswapTokenPrice'
-import { formatTokenAmount } from '@utils/token-utils'
-import tokenIcon from '@assets/honey.svg'
+import { formatTokenAmount, getTokenIconBySymbol } from '@utils/token-utils'
 
 function BalanceCard({
   allowance,
@@ -63,7 +62,7 @@ function BalanceCard({
       `}
     >
       <img
-        src={tokenIcon}
+        src={getTokenIconBySymbol(tokenSymbol)} // TODO: Use default-token-list
         width={6.5 * GU}
         height={6.5 * GU}
         css={`

--- a/src/hooks/useDispute.js
+++ b/src/hooks/useDispute.js
@@ -3,6 +3,7 @@ import { getNetwork } from '@/networks'
 import arbitratorAbi from '@abis/arbitrator.json'
 import disputeManagerAbi from '@abis/DisputeManager.json'
 import { useContractReadOnly } from './useContract'
+import BigNumber from '@lib/bigNumber'
 import { DISPUTE_STATE_ADJUDICATING } from '@utils/dispute-utils'
 
 export function useDisputeState(disputeId) {
@@ -90,7 +91,7 @@ export function useDisputeFees() {
 
       if (!cancelled) {
         setFees({
-          amount: result.feeAmount,
+          amount: new BigNumber(result.feeAmount.toString()),
           token: result.feeToken,
           loading: false,
         })

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import { useContractReadOnly } from './useContract'
+import { useMounted } from './useMounted'
+import tokenAbi from '@abis/minimeToken.json'
+import BigNumber from '@lib/bigNumber'
+
+export function useTokenBalanceOf(tokenAddress, account) {
+  const [balance, setBalance] = useState(new BigNumber(-1))
+  const tokenContract = useContractReadOnly(tokenAddress, tokenAbi)
+
+  useEffect(() => {
+    const fetchTokenBalanceOf = async () => {
+      const result = await tokenContract.balanceOf(account)
+
+      setBalance(new BigNumber(result.toString()))
+    }
+
+    fetchTokenBalanceOf()
+  }, [account, tokenContract])
+
+  return balance
+}
+
+export function useTokenData(tokenAddress) {
+  const [tokenData, setTokenData] = useState({ decimals: 18, symbol: '' })
+  const [loading, setLoading] = useState(true)
+
+  const mounted = useMounted()
+  const tokenContract = useContractReadOnly(tokenAddress, tokenAbi)
+
+  useEffect(() => {
+    const fetchTokenData = async () => {
+      const decimals = await tokenContract.decimals()
+      const symbol = await tokenContract.symbol()
+
+      if (mounted()) {
+        setTokenData({ decimals, symbol })
+        setLoading(false)
+      }
+    }
+
+    fetchTokenData()
+  }, [mounted, tokenContract])
+
+  return [tokenData, loading]
+}

--- a/src/utils/token-utils.js
+++ b/src/utils/token-utils.js
@@ -1,10 +1,4 @@
-import { toUtf8 } from './web3-utils'
 import { round } from './math-utils'
-import tokenSymbolAbi from '@abis/token-symbol.json'
-import tokenSymbolBytesAbi from '@abis/token-symbol-bytes.json'
-import tokenNameAbi from '@abis/token-name.json'
-import tokenNameBytesAbi from '@abis/token-name-bytes.json'
-
 import defaultTokenSvg from '@assets/defaultTokenLogo.svg'
 import honeyIconSvg from '@assets/honey.svg'
 import stableTokenSvg from '@assets/stable-token.svg'
@@ -61,38 +55,6 @@ export const tokenDataFallback = (tokenAddress, fieldName, networkType) => {
     return null
   }
   return fallbacksForNetwork.get(addressWithoutChecksum)[fieldName] || null
-}
-
-export async function getTokenSymbol(app, address) {
-  // Symbol is optional; note that aragon.js doesn't return an error (only an falsey value) when
-  // getting this value fails
-  let tokenSymbol
-  try {
-    const token = app.external(address, tokenSymbolAbi)
-    tokenSymbol = await token.symbol().toPromise()
-  } catch (err) {
-    // Some tokens (e.g. DS-Token) use bytes32 as the return type for symbol().
-    const token = app.external(address, tokenSymbolBytesAbi)
-    tokenSymbol = toUtf8(await token.symbol().toPromise())
-  }
-
-  return tokenSymbol || null
-}
-
-export async function getTokenName(app, address) {
-  // Name is optional; note that aragon.js doesn't return an error (only an falsey value) when
-  // getting this value fails
-  let tokenName
-  try {
-    const token = app.external(address, tokenNameAbi)
-    tokenName = await token.name().toPromise()
-  } catch (err) {
-    // Some tokens (e.g. DS-Token) use bytes32 as the return type for name().
-    const token = app.external(address, tokenNameBytesAbi)
-    tokenName = toUtf8(await token.name().toPromise())
-  }
-
-  return tokenName || null
 }
 
 export function getPresetTokens(networkType) {


### PR DESCRIPTION
closes #448 , closes #450, closes #447

- Fixes create proposal modal not popping when being redirected from collateral manager
- Challenge actions: 2 Approves (one for collateral amount, one for dispute fee amount) since collateral token and dispute fee token can be different. If tokens are the same, then one approve for the added amount.
- useDisputeFees: Returns amount converted in BN so that components don't need to handle this.   
- Challenge requirements: Uses dispute fee token data and account balance (previously using collateral token data)
- Raise Dispute requirements: Uses dispute fee token data and account balance (previously using collateral token data)