### PR TITLE
Use vault address from config.conviction

### DIFF
--- a/src/hooks/useGardenHooks.js
+++ b/src/hooks/useGardenHooks.js
@@ -15,7 +15,7 @@ import { useConfigSubscription } from './useSubscriptions'
 import env from '@/environment'
 import BigNumber from '@lib/bigNumber'
 import { addressesEqual } from '@utils/web3-utils'
-import { getAppAddressByName, getAppByName } from '@utils/data-utils'
+import { getAppByName } from '@utils/data-utils'
 import { connectorConfig } from '@/networks'
 
 // abis
@@ -108,12 +108,8 @@ export function useGardenData() {
   }
 }
 
-export function useCommonPool(installedApps, token, timeout = 3000) {
-  const vaultAddress =
-    getAppAddressByName(installedApps, 'vault') ||
-    getAppAddressByName(installedApps, 'agent')
+export function useCommonPool(vaultAddress, token, timeout = 3000) {
   const vaultContract = useContractReadOnly(vaultAddress, vaultAbi)
-
   const [commonPool, setCommonPool] = useState(new BigNumber(-1))
 
   useEffect(() => {

--- a/src/providers/GardenState.js
+++ b/src/providers/GardenState.js
@@ -24,7 +24,7 @@ function GardenStateProvider({ children }) {
   const [tokens, tokensLoading] = useTokens()
 
   const commonPool = useCommonPool(
-    installedApps,
+    config?.conviction.vault,
     (tokens.wrappableToken || tokens.token).data
   )
   const effectiveSupply = useEffectiveSupply(tokens.token.totalSupply, config)


### PR DESCRIPTION
MERGE AFTER SUBGRAPH DEPLOYED

Uses the vault address (new added attribute) from `config.conviction` see https://github.com/1Hive/gardens/pull/124

Newly crated gardens will have two agents, so we need which one to use

