### PR TITLE
Header and Footer: Adjust height

### DIFF
--- a/src/components/Garden/Footer.js
+++ b/src/components/Garden/Footer.js
@@ -60,7 +60,7 @@ function Footer() {
             `}
           >
             <div>
-              <img src={logoSvg} height="40" alt="" />
+              <img src={logoSvg} height="60" alt="" />
             </div>
             {links?.community && (
               <div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -67,7 +67,11 @@ function Header() {
                 display: flex;
               `}
             >
-              {layoutSmall ? Logo : <img src={logotype} height="40" alt="" />}
+              {layoutSmall ? (
+                Logo
+              ) : (
+                <img src={logotype} height={connectedGarden ? 40 : 24} alt="" />
+              )}
             </Link>
             {!below('large') && (
               <nav


### PR DESCRIPTION
- Header: Decreases logo height for gardens logo
- Footer: Increases logo height (now that most logos have the circular background with the previous height made it look smaller)