### PR TITLE
Use default provider

### DIFF
--- a/src/components/IdentityBadge.js
+++ b/src/components/IdentityBadge.js
@@ -3,16 +3,16 @@ import { useHistory } from 'react-router-dom'
 import { IdentityBadge as Badge } from '@1hive/1hive-ui'
 
 import { getNetwork } from '@/networks'
-import { getNetworkType } from '@utils/web3-utils'
 import { getProfileForAccount } from '@lib/profile'
 
 const addressCache = new Map()
 
 const IdentityBadge = React.memo(function IdentityBadge({ entity, ...props }) {
   const [profileName, setProfileName] = useState(null)
-
-  const networkType = getNetworkType()
   const history = useHistory()
+
+  const { explorer, type } = getNetwork()
+
   const handleViewProfile = useCallback(() => {
     history.push(`/profile?account=${entity}`)
   }, [entity, history])
@@ -41,8 +41,8 @@ const IdentityBadge = React.memo(function IdentityBadge({ entity, ...props }) {
     <Badge
       label={profileName}
       entity={entity}
-      explorerProvider={getNetwork().explorer}
-      networkType={networkType}
+      explorerProvider={explorer}
+      networkType={type}
       popoverAction={{ label: 'View profile', onClick: handleViewProfile }}
       {...props}
     />

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,4 +1,4 @@
-// rinkeby
+// xdai
 const DEFAULT_CHAIN_ID = 100
 
 const DEFAULT_AGREEMENT_APP_NAME = 'agreement'
@@ -13,6 +13,9 @@ const ENV_VARS = {
       process.env.REACT_APP_AGREEMENT_APP_NAME || DEFAULT_AGREEMENT_APP_NAME
     )
   },
+  ALCHEMY_API_KEY() {
+    return process.env.REACT_APP_ALCHEMY_API_KEY || null
+  },
   CHAIN_ID() {
     const chainId = parseInt(process.env.REACT_APP_CHAIN_ID)
     return isNaN(chainId) ? DEFAULT_CHAIN_ID : chainId
@@ -25,11 +28,23 @@ const ENV_VARS = {
   ETH_NODE() {
     return process.env.REACT_APP_ETH_NODE || ''
   },
+  ETHERSCAN_API_KEY() {
+    return process.env.REACT_APP_ETHERSCAN_API_KEY || null
+  },
   INTERCOM_APP_ID() {
     return process.env.REACT_APP_INTERCOM_APP_ID || ''
   },
   FORTMATIC_API_KEY() {
     return process.env.REACT_APP_FORTMATIC_API_KEY || ''
+  },
+  HOOKED_TOKEN_MANAGER_APP_NAME() {
+    return (
+      process.env.REACT_APP_HOOKED_TOKEN_MANAGER_APP_NAME ||
+      DEFAULT_HOOKED_TOKEN_MANAGER
+    )
+  },
+  INFURA_API_KEY() {
+    return process.env.REACT_APP_INFURA_API_KEY || null
   },
   INSTANCE() {
     return process.env.REACT_APP_APP_INSTANCE || ''
@@ -37,14 +52,11 @@ const ENV_VARS = {
   ISSUANCE_APP_NAME() {
     return process.env.REACT_APP_ISSUANCE_APP_NAME || DEFAULT_ISSUANCE_APP_NAME
   },
+  POCKET_API_KEY() {
+    return process.env.REACT_APP_POCKET_API_KEY || null
+  },
   VOTING_APP_NAME() {
     return process.env.REACT_APP_VOTING_APP_NAME || DEFAULT_VOTING_APP_NAME
-  },
-  HOOKED_TOKEN_MANAGER_APP_NAME() {
-    return (
-      process.env.REACT_APP_HOOKED_TOKEN_MANAGER_APP_NAME ||
-      DEFAULT_HOOKED_TOKEN_MANAGER
-    )
   },
 }
 

--- a/src/hooks/useContract.js
+++ b/src/hooks/useContract.js
@@ -1,21 +1,15 @@
 import { useMemo } from 'react'
-import { Contract as EthersContract, providers as Providers } from 'ethers'
+import { Contract as EthersContract } from 'ethers'
 import { useWallet } from '@providers/Wallet'
-
-import { getNetwork } from '../networks'
-
-const ethEndpoint = getNetwork().defaultEthNode
-const DEFAULT_PROVIDER = new Providers.StaticJsonRpcProvider(ethEndpoint)
+import { getDefaultProvider } from '@utils/web3-utils'
 
 export function useContractReadOnly(address, abi) {
-  const ethProvider = useMemo(() => (ethEndpoint ? DEFAULT_PROVIDER : null), [])
-
   return useMemo(() => {
     if (!address) {
       return null
     }
-    return getContract(address, abi, ethProvider)
-  }, [abi, address, ethProvider])
+    return getContract(address, abi)
+  }, [abi, address])
 }
 
 export function useContract(address, abi, signer = true) {
@@ -33,6 +27,6 @@ export function useContract(address, abi, signer = true) {
   }, [abi, account, address, ethers, signer])
 }
 
-export function getContract(address, abi, provider = DEFAULT_PROVIDER) {
+export function getContract(address, abi, provider = getDefaultProvider()) {
   return new EthersContract(address, abi, provider)
 }

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -15,7 +15,7 @@ function setLocalSetting(confKey, value) {
 }
 
 export function getDefaultChain() {
-  return Number(env(DEFAULT_CHAIN_ID)) || ''
+  return Number(env(DEFAULT_CHAIN_ID))
 }
 
 export function setDefaultChain(chainId) {

--- a/src/providers/Wallet.js
+++ b/src/providers/Wallet.js
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react'
 import { providers as EthersProviders } from 'ethers'
 import { UseWalletProvider, useWallet } from 'use-wallet'
-import { getUseWalletConnectors } from '@utils/web3-utils'
+import { getUseWalletConnectors, getDefaultProvider } from '@utils/web3-utils'
 import { getNetwork } from '@/networks'
 import { getDefaultChain } from '@/local-settings'
 
@@ -18,9 +18,7 @@ function WalletAugmented({ children }) {
 
   const ethers = useMemo(() => {
     if (!ethereum) {
-      return new EthersProviders.StaticJsonRpcProvider(
-        getNetwork()?.defaultEthNode
-      )
+      return getDefaultProvider()
     }
 
     const ensRegistry = getNetwork()?.ensRegistry

--- a/src/utils/web3-utils.js
+++ b/src/utils/web3-utils.js
@@ -9,7 +9,7 @@ function getBackendServicesKeys() {
   return {
     alchemy: env('ALCHEMY_API_KEY'),
     etherscan: env('ETHERSCAN_API_KEY'),
-    infura: env('INFURA_API_KEY') || null,
+    infura: env('INFURA_API_KEY'),
     pocket: env('POCKET_API_KEY'),
   }
 }

--- a/src/utils/web3-utils.js
+++ b/src/utils/web3-utils.js
@@ -1,8 +1,27 @@
+import { ethers, providers as Providers } from 'ethers'
 import { toChecksumAddress } from 'web3-utils'
-import env from '../environment'
-import { getDefaultChain } from '../local-settings'
+import env from '@/environment'
+import { getDefaultChain } from '@/local-settings'
 
 const DEFAULT_LOCAL_CHAIN = ''
+
+function getBackendServicesKeys() {
+  return {
+    alchemy: env('ALCHEMY_API_KEY'),
+    etherscan: env('ETHERSCAN_API_KEY'),
+    infura: env('INFURA_API_KEY') || null,
+    pocket: env('POCKET_API_KEY'),
+  }
+}
+
+export function getDefaultProvider() {
+  const type = getNetworkType()
+  const defaultEthNode = env('ETH_NODE')
+
+  return defaultEthNode
+    ? new Providers.StaticJsonRpcProvider(defaultEthNode)
+    : ethers.getDefaultProvider(type, getBackendServicesKeys())
+}
 
 export function encodeFunctionData(contract, functionName, params) {
   return contract.interface.encodeFunctionData(functionName, params)
@@ -19,19 +38,6 @@ export function getUseWalletProviders() {
   }
 
   return providers
-}
-
-export function isLocalOrUnknownNetwork(chainId = getDefaultChain()) {
-  return getNetworkType(chainId) === DEFAULT_LOCAL_CHAIN
-}
-
-export function getUseWalletConnectors() {
-  return getUseWalletProviders().reduce((connectors, provider) => {
-    if (provider.useWalletConf) {
-      connectors[provider.id] = provider.useWalletConf
-    }
-    return connectors
-  }, {})
 }
 
 export function getNetworkType(chainId = getDefaultChain()) {
@@ -54,6 +60,19 @@ export function getNetworkName(chainId = getDefaultChain()) {
   if (chainId === '100') return 'xDai'
 
   return 'unknown'
+}
+
+export function isLocalOrUnknownNetwork(chainId = getDefaultChain()) {
+  return getNetworkType(chainId) === DEFAULT_LOCAL_CHAIN
+}
+
+export function getUseWalletConnectors() {
+  return getUseWalletProviders().reduce((connectors, provider) => {
+    if (provider.useWalletConf) {
+      connectors[provider.id] = provider.useWalletConf
+    }
+    return connectors
+  }, {})
 }
 
 // Check address equality with checksums


### PR DESCRIPTION
Uses as provider the `defaultProvider` from ethers only if no `ETH_NODE` is set on startup. This is because most of the backend services accepted by `defaultProvider` don't support xdai as far as i could tell. 

It's also nice to have this possibility so that when developing you only need to pass your personal eth endpoint instead of all your backend services api keys (if any).

Note that when no api keys are provided `getDefaultProvider` uses some default keys which are used amongst all devs.

TODO: Add pocket network