### PR TITLE
Collateral manager: Improve deposit flow

### DIFF
--- a/src/components/Garden/ModalFlows/CreateProposalScreens/CreateProposalRequirements.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/CreateProposalRequirements.js
@@ -138,6 +138,11 @@ function CollateralStatus({ allowance, availableStaked, actionAmount, token }) {
     history.push(path)
   }, [history])
 
+  const goToStakeManagerDeposit = useCallback(() => {
+    const path = buildGardenPath(history.location, 'collateral/deposit')
+    history.push(path)
+  }, [history])
+
   const infoData = useMemo(() => {
     if (!availableStaked.gte(actionAmount)) {
       return {
@@ -149,7 +154,7 @@ function CollateralStatus({ allowance, availableStaked, actionAmount, token }) {
           token.decimals
         )} ${token.symbol} as the action collateral.`,
         actionButton: 'Deposit collateral',
-        buttonOnClick: goToStakeManager,
+        buttonOnClick: goToStakeManagerDeposit,
       }
     }
 
@@ -173,7 +178,15 @@ function CollateralStatus({ allowance, availableStaked, actionAmount, token }) {
         token.decimals
       )} ${token.symbol} as the action collateral.`,
     }
-  }, [allowance, availableStaked, actionAmount, token, goToStakeManager, theme])
+  }, [
+    actionAmount,
+    allowance,
+    availableStaked,
+    goToStakeManager,
+    goToStakeManagerDeposit,
+    theme,
+    token,
+  ])
 
   return <InfoBox data={infoData} />
 }

--- a/src/components/Garden/Stake/StakeManagement.js
+++ b/src/components/Garden/Stake/StakeManagement.js
@@ -1,4 +1,5 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useHistory } from 'react-router'
 import { Header } from '@1hive/1hive-ui'
 import EmptyState from './EmptyState'
 import LayoutColumns from '../Layout/LayoutColumns'
@@ -15,6 +16,7 @@ import { useWallet } from '@providers/Wallet'
 
 const StakeManagement = React.memo(function StakeManagement() {
   const { account } = useWallet()
+  const history = useHistory()
   const [stakeModalMode, setStakeModalMode] = useState()
   const { stakeManagement, stakeActions, loading } = useStakingState()
 
@@ -22,6 +24,13 @@ const StakeManagement = React.memo(function StakeManagement() {
     stakeActions.reFetchTotalBalance()
     setStakeModalMode(null)
   }, [stakeActions])
+
+  useEffect(() => {
+    // Components that redirect to deposit collateral will do so through "garden/${gardenId}/collateral/deposit" url
+    if (account && history.location.pathname.includes('deposit')) {
+      setStakeModalMode('deposit')
+    }
+  }, [account, history])
 
   const orderedStakingMovements = useMemo(() => {
     if (!stakeManagement?.stakingMovements) {

--- a/src/routes/garden/Routes.js
+++ b/src/routes/garden/Routes.js
@@ -12,7 +12,7 @@ export default function Routes() {
       <Route exact path="*/proposal/:id" component={ProposalLoader} />
       <Route exact path="*/vote/:id" component={DecisionLoader} />
       <Route exact path="*/covenant" component={Agreement} />
-      <Route exact path="*/collateral" component={StakeManagement} />
+      <Route exact path="*/collateral/*" component={StakeManagement} />
       <Route path="*/" component={Home} />
     </Switch>
   )


### PR DESCRIPTION
closes #449 

Was wondering if we should apply the same behavior to the Allow garden action since it straight up prompts you to sign the tx? 

When going to the collateral screen from the proposal requirements modal
![Screen Shot 2021-05-31 at 15 47 57](https://user-images.githubusercontent.com/22663232/120231354-9ab50600-c227-11eb-8c9a-6127d1d79499.png)

The new route is `collateral/deposit` which if detected it will open up the modal after page load.
![Screen Shot 2021-05-31 at 15 48 06](https://user-images.githubusercontent.com/22663232/120231389-b15b5d00-c227-11eb-8312-a2d400b899ce.png)
