### PR TITLE
Onboarding backbone

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,18 +1,29 @@
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import GardensList from './GardensList'
+import Onboarding from './Onboarding'
 import LandingBanner from './LandingBanner'
 import { useNodeHeight } from '@hooks/useNodeHeight'
 
 function Home() {
   const [height, ref] = useNodeHeight()
+  const [onboardingVisible, setOnboardingVisible] = useState(false)
+
+  const handleOnboardingOpen = useCallback(() => {
+    setOnboardingVisible(true)
+  }, [])
+
+  const handleOnboardingClose = useCallback(() => {
+    setOnboardingVisible(false)
+  }, [])
 
   return (
     <div>
-      <LandingBanner ref={ref} />
+      <LandingBanner ref={ref} onCreateGarden={handleOnboardingOpen} />
       <DynamicDiv marginTop={height}>
         <GardensList />
       </DynamicDiv>
+      <Onboarding onClose={handleOnboardingClose} visible={onboardingVisible} />
     </div>
   )
 }

--- a/src/components/LandingBanner.js
+++ b/src/components/LandingBanner.js
@@ -115,7 +115,7 @@ const LandingBanner = React.forwardRef(({ onCreateGarden }, ref) => {
                 `}
               />
               <Button
-                label="Create Garden"
+                label="Grow Garden"
                 mode="strong"
                 onClick={onCreateGarden}
                 wide

--- a/src/components/LandingBanner.js
+++ b/src/components/LandingBanner.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button, GU, useLayout, useTheme } from '@1hive/1hive-ui'
+import { useWallet } from '@providers/Wallet'
 
 import desktopBanner from '@assets/landingBanner.png'
 import mobileBanner from '@assets/landingBanner-mobile.png'
@@ -32,8 +33,9 @@ const BANNERS = {
   },
 }
 
-const LandingBanner = React.forwardRef((props, ref) => {
+const LandingBanner = React.forwardRef(({ onCreateGarden }, ref) => {
   const theme = useTheme()
+  const { account } = useWallet()
   const { layoutName } = useLayout()
 
   const { aspectRatio, hFontSize, image, pFontSize } = BANNERS[layoutName]
@@ -113,10 +115,11 @@ const LandingBanner = React.forwardRef((props, ref) => {
                 `}
               />
               <Button
-                label="Overview"
-                href="https://gardens.substack.com/p/introducing-gardens"
+                label="Create Garden"
                 mode="strong"
+                onClick={onCreateGarden}
                 wide
+                disabled={!account}
               />
             </div>
           </div>

--- a/src/components/Onboarding/Navigation.js
+++ b/src/components/Onboarding/Navigation.js
@@ -45,7 +45,7 @@ const Navigation = React.forwardRef(function Navigation(
       <Button
         ref={nextRef}
         disabled={!nextEnabled}
-        label="Next"
+        label={nextLabel}
         mode="strong"
         onClick={onNext}
         type="submit"

--- a/src/components/Onboarding/Navigation.js
+++ b/src/components/Onboarding/Navigation.js
@@ -1,0 +1,76 @@
+import React, { useRef, useImperativeHandle } from 'react'
+import PropTypes from 'prop-types'
+import { Button, IconArrowLeft, GU, useTheme } from '@1hive/1hive-ui'
+
+const Navigation = React.forwardRef(function Navigation(
+  { backEnabled, backLabel, nextEnabled, nextLabel, onBack, onNext },
+  ref
+) {
+  const theme = useTheme()
+
+  const nextRef = useRef()
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focusNext: () => {
+        if (nextRef.current) {
+          nextRef.current.focus()
+        }
+      },
+    }),
+    []
+  )
+
+  return (
+    <div
+      css={`
+        display: flex;
+        width: 100%;
+        justify-content: space-between;
+      `}
+    >
+      <Button
+        disabled={!backEnabled}
+        icon={
+          <IconArrowLeft
+            css={`
+              color: ${theme.accent};
+            `}
+          />
+        }
+        label={backLabel}
+        onClick={onBack}
+      />
+      <Button
+        ref={nextRef}
+        disabled={!nextEnabled}
+        label="Next"
+        mode="strong"
+        onClick={onNext}
+        type="submit"
+        css={`
+          margin-left: ${1.5 * GU}px;
+        `}
+      />
+    </div>
+  )
+})
+
+Navigation.propTypes = {
+  backEnabled: PropTypes.bool.isRequired,
+  backLabel: PropTypes.string.isRequired,
+  nextEnabled: PropTypes.bool.isRequired,
+  nextLabel: PropTypes.string.isRequired,
+  onBack: PropTypes.func.isRequired,
+  onNext: PropTypes.func.isRequired,
+}
+
+Navigation.defaultProps = {
+  backEnabled: true,
+  backLabel: 'Back',
+  nextEnabled: true,
+  nextLabel: 'Next',
+}
+
+export default Navigation

--- a/src/components/Onboarding/Screens/Apps/AgreementSettings.js
+++ b/src/components/Onboarding/Screens/Apps/AgreementSettings.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function AgreementSettings() {
+  return <div>Agreement settings</div>
+}
+
+export default AgreementSettings

--- a/src/components/Onboarding/Screens/Apps/AgreementSettings.js
+++ b/src/components/Onboarding/Screens/Apps/AgreementSettings.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../../Navigation'
 
 function AgreementSettings() {
-  return <div>Agreement settings</div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Agreement settings
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default AgreementSettings

--- a/src/components/Onboarding/Screens/Apps/AgreementSettings.js
+++ b/src/components/Onboarding/Screens/Apps/AgreementSettings.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../../Navigation'
 
-function AgreementSettings() {
-  const { onBack, onNext } = useOnboardingState()
+function AgreementSettings({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      Agreement settings
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings.js
+++ b/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../../Navigation'
 
 function ConvictionVotingSettings() {
-  return <div>Conviction voting settings</div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Conviction voting settings
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default ConvictionVotingSettings

--- a/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings.js
+++ b/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../../Navigation'
 
-function ConvictionVotingSettings() {
-  const { onBack, onNext } = useOnboardingState()
+function ConvictionVotingSettings({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      Conviction voting settings
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings.js
+++ b/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function ConvictionVotingSettings() {
+  return <div>Conviction voting settings</div>
+}
+
+export default ConvictionVotingSettings

--- a/src/components/Onboarding/Screens/Apps/IssuanceSettings.js
+++ b/src/components/Onboarding/Screens/Apps/IssuanceSettings.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function IssuanceSettings() {
+  return <div>Issuance settings</div>
+}
+
+export default IssuanceSettings

--- a/src/components/Onboarding/Screens/Apps/IssuanceSettings.js
+++ b/src/components/Onboarding/Screens/Apps/IssuanceSettings.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../../Navigation'
 
 function IssuanceSettings() {
-  return <div>Issuance settings</div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Issuance settings
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default IssuanceSettings

--- a/src/components/Onboarding/Screens/Apps/IssuanceSettings.js
+++ b/src/components/Onboarding/Screens/Apps/IssuanceSettings.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../../Navigation'
 
-function IssuanceSettings() {
-  const { onBack, onNext } = useOnboardingState()
+function IssuanceSettings({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      Issuance settings
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/Apps/TokensSettings.js
+++ b/src/components/Onboarding/Screens/Apps/TokensSettings.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../../Navigation'
 
 function TokensSettings() {
-  return <div>Tokens settings</div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Tokens settings
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default TokensSettings

--- a/src/components/Onboarding/Screens/Apps/TokensSettings.js
+++ b/src/components/Onboarding/Screens/Apps/TokensSettings.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../../Navigation'
 
-function TokensSettings() {
-  const { onBack, onNext } = useOnboardingState()
+function TokensSettings({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      Tokens settings
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/Apps/TokensSettings.js
+++ b/src/components/Onboarding/Screens/Apps/TokensSettings.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function TokensSettings() {
+  return <div>Tokens settings</div>
+}
+
+export default TokensSettings

--- a/src/components/Onboarding/Screens/Apps/VotingSettings.js
+++ b/src/components/Onboarding/Screens/Apps/VotingSettings.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function VotingSettings() {
+  return <div>VotingSettings</div>
+}
+
+export default VotingSettings

--- a/src/components/Onboarding/Screens/Apps/VotingSettings.js
+++ b/src/components/Onboarding/Screens/Apps/VotingSettings.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../../Navigation'
 
-function VotingSettings() {
-  const { onBack, onNext } = useOnboardingState()
+function VotingSettings({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      VotingSettings
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/Apps/VotingSettings.js
+++ b/src/components/Onboarding/Screens/Apps/VotingSettings.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../../Navigation'
 
 function VotingSettings() {
-  return <div>VotingSettings</div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      VotingSettings
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default VotingSettings

--- a/src/components/Onboarding/Screens/GardenMetadata.js
+++ b/src/components/Onboarding/Screens/GardenMetadata.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../Navigation'
 
-function GardenMetadata() {
-  const { onBack, onNext } = useOnboardingState()
+function GardenMetadata({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      GardenMetadata
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/GardenMetadata.js
+++ b/src/components/Onboarding/Screens/GardenMetadata.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function GardenMetadata() {
+  return <div>GardenMetadata</div>
+}
+
+export default GardenMetadata

--- a/src/components/Onboarding/Screens/GardenMetadata.js
+++ b/src/components/Onboarding/Screens/GardenMetadata.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../Navigation'
 
 function GardenMetadata() {
-  return <div>GardenMetadata</div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      GardenMetadata
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default GardenMetadata

--- a/src/components/Onboarding/Screens/GardenTypeSelector.js
+++ b/src/components/Onboarding/Screens/GardenTypeSelector.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../Navigation'
 
-function GardenTypeSelector() {
-  const { onBack, onNext } = useOnboardingState()
+function GardenTypeSelector({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      Garden type
+      {title}
       <Navigation
         backEnabled={false}
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/GardenTypeSelector.js
+++ b/src/components/Onboarding/Screens/GardenTypeSelector.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function GardenTypeSelector() {
+  return <div>Garden type</div>
+}
+
+export default GardenTypeSelector

--- a/src/components/Onboarding/Screens/GardenTypeSelector.js
+++ b/src/components/Onboarding/Screens/GardenTypeSelector.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../Navigation'
 
 function GardenTypeSelector() {
-  return <div>Garden type</div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Garden type
+      <Navigation
+        backEnabled={false}
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default GardenTypeSelector

--- a/src/components/Onboarding/Screens/HoneyswapLiquidity.js
+++ b/src/components/Onboarding/Screens/HoneyswapLiquidity.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../Navigation'
 
-function HoneyswapLiquidity() {
-  const { onBack, onNext } = useOnboardingState()
+function HoneyswapLiquidity({ title }) {
+  const { onBack, onNext, step, steps } = useOnboardingState()
 
   return (
     <div>
-      Honeyswap
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel={`Next: ${steps[step + 1].title}`}
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/HoneyswapLiquidity.js
+++ b/src/components/Onboarding/Screens/HoneyswapLiquidity.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function HoneyswapLiquidity() {
+  return <div>Honeyswap </div>
+}
+
+export default HoneyswapLiquidity

--- a/src/components/Onboarding/Screens/HoneyswapLiquidity.js
+++ b/src/components/Onboarding/Screens/HoneyswapLiquidity.js
@@ -1,7 +1,22 @@
 import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../Navigation'
 
 function HoneyswapLiquidity() {
-  return <div>Honeyswap </div>
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Honeyswap
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
 }
 
 export default HoneyswapLiquidity

--- a/src/components/Onboarding/Screens/LaunchGarden.js
+++ b/src/components/Onboarding/Screens/LaunchGarden.js
@@ -2,16 +2,15 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../Navigation'
 
-function ReviewInformation() {
+function LaunchGarden({ title }) {
   const { onBack, onNext } = useOnboardingState()
 
   return (
     <div>
-      Launch Garden
+      {title}
       <Navigation
         backEnabled
-        nextEnabled
-        nextLabel="Next:"
+        nextEnabled={false}
         onBack={onBack}
         onNext={onNext}
       />
@@ -19,4 +18,4 @@ function ReviewInformation() {
   )
 }
 
-export default ReviewInformation
+export default LaunchGarden

--- a/src/components/Onboarding/Screens/LaunchGarden.js
+++ b/src/components/Onboarding/Screens/LaunchGarden.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../Navigation'
+
+function ReviewInformation() {
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Launch Garden
+      <Navigation
+        backEnabled={false}
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
+}
+
+export default ReviewInformation

--- a/src/components/Onboarding/Screens/LaunchGarden.js
+++ b/src/components/Onboarding/Screens/LaunchGarden.js
@@ -9,7 +9,7 @@ function ReviewInformation() {
     <div>
       Launch Garden
       <Navigation
-        backEnabled={false}
+        backEnabled
         nextEnabled
         nextLabel="Next:"
         onBack={onBack}

--- a/src/components/Onboarding/Screens/ReviewInformation.js
+++ b/src/components/Onboarding/Screens/ReviewInformation.js
@@ -2,16 +2,16 @@ import React from 'react'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../Navigation'
 
-function ReviewInformation() {
+function ReviewInformation({ title }) {
   const { onBack, onNext } = useOnboardingState()
 
   return (
     <div>
-      Review information
+      {title}
       <Navigation
         backEnabled
         nextEnabled
-        nextLabel="Next:"
+        nextLabel="Launch your garden"
         onBack={onBack}
         onNext={onNext}
       />

--- a/src/components/Onboarding/Screens/ReviewInformation.js
+++ b/src/components/Onboarding/Screens/ReviewInformation.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useOnboardingState } from '@providers/Onboarding'
+import Navigation from '../Navigation'
+
+function ReviewInformation() {
+  const { onBack, onNext } = useOnboardingState()
+
+  return (
+    <div>
+      Review information
+      <Navigation
+        backEnabled={false}
+        nextEnabled
+        nextLabel="Next:"
+        onBack={onBack}
+        onNext={onNext}
+      />
+    </div>
+  )
+}
+
+export default ReviewInformation

--- a/src/components/Onboarding/Screens/ReviewInformation.js
+++ b/src/components/Onboarding/Screens/ReviewInformation.js
@@ -9,7 +9,7 @@ function ReviewInformation() {
     <div>
       Review information
       <Navigation
-        backEnabled={false}
+        backEnabled
         nextEnabled
         nextLabel="Next:"
         onBack={onBack}

--- a/src/components/Onboarding/Screens/config.js
+++ b/src/components/Onboarding/Screens/config.js
@@ -1,0 +1,19 @@
+import AgreementSettings from './Apps/AgreementSettings'
+import ConvictionVotingSettings from './Apps/ConvictionVotingSettings'
+import IssuanceSettings from './Apps/IssuanceSettings'
+import TokensSettings from './Apps/TokensSettings'
+import VotingSettings from './Apps/VotingSettings'
+import GardenTypeSelector from './GardenTypeSelector'
+import GardenMetadata from './GardenMetadata'
+import HoneyswapLiquidity from './HoneyswapLiquidity'
+
+export const Screens = [
+  { Screen: GardenTypeSelector, title: 'Type selection' },
+  { Screen: GardenMetadata, title: 'Garden data' },
+  { Screen: HoneyswapLiquidity, title: 'HoneyswapLiquidity' },
+  { Screen: TokensSettings, title: 'Tokens settings' },
+  { Screen: VotingSettings, title: 'Voting settings' },
+  { Screen: ConvictionVotingSettings, title: 'Conviction voting settings' },
+  { Screen: IssuanceSettings, title: 'Issuance settings' },
+  { Screen: AgreementSettings, title: 'Covenant settings' },
+]

--- a/src/components/Onboarding/Screens/config.js
+++ b/src/components/Onboarding/Screens/config.js
@@ -9,15 +9,54 @@ import ReviewInformation from './ReviewInformation'
 import TokensSettings from './Apps/TokensSettings'
 import VotingSettings from './Apps/VotingSettings'
 
+const STEPS = [
+  'Select garden type',
+  'Configure garden',
+  'Review information',
+  'Launch Garden',
+]
+
 export const Screens = [
-  { Screen: GardenTypeSelector, title: 'Type selection' },
-  { Screen: GardenMetadata, title: 'Garden data' },
-  { Screen: HoneyswapLiquidity, title: 'Honeyswap Liquidity' },
-  { Screen: TokensSettings, title: 'Tokens settings' },
-  { Screen: VotingSettings, title: 'Voting settings' },
-  { Screen: ConvictionVotingSettings, title: 'Conviction Voting settings' },
-  { Screen: IssuanceSettings, title: 'Issuance settings' },
-  { Screen: AgreementSettings, title: 'Covenant settings' },
-  { Screen: ReviewInformation, title: 'Review information' },
-  { Screen: LaunchGarden, title: 'Launch Garden' },
+  {
+    key: STEPS[0],
+    title: 'Type selection',
+    Screen: GardenTypeSelector,
+  },
+  { key: STEPS[1], title: 'Garden data', Screen: GardenMetadata },
+  {
+    key: STEPS[1],
+    title: 'Honeyswap Liquidity',
+    Screen: HoneyswapLiquidity,
+  },
+  {
+    key: STEPS[1],
+    title: 'Tokens settings',
+    Screen: TokensSettings,
+  },
+  {
+    key: STEPS[1],
+    title: 'Voting settings',
+    Screen: VotingSettings,
+  },
+  {
+    key: STEPS[1],
+    title: 'Conviction Voting settings',
+    Screen: ConvictionVotingSettings,
+  },
+  {
+    key: STEPS[1],
+    title: 'Issuance settings',
+    Screen: IssuanceSettings,
+  },
+  {
+    key: STEPS[1],
+    title: 'Covenant settings',
+    Screen: AgreementSettings,
+  },
+  {
+    key: STEPS[2],
+    title: 'Review information',
+    Screen: ReviewInformation,
+  },
+  { key: STEPS[3], title: 'Launch Garden', Screen: LaunchGarden },
 ]

--- a/src/components/Onboarding/Screens/config.js
+++ b/src/components/Onboarding/Screens/config.js
@@ -22,7 +22,7 @@ export const Screens = [
     title: 'Type selection',
     Screen: GardenTypeSelector,
   },
-  { key: STEPS[1], title: 'Garden data', Screen: GardenMetadata },
+  { key: STEPS[1], title: 'Garden metadata', Screen: GardenMetadata },
   {
     key: STEPS[1],
     title: 'Honeyswap Liquidity',

--- a/src/components/Onboarding/Screens/config.js
+++ b/src/components/Onboarding/Screens/config.js
@@ -10,10 +10,10 @@ import HoneyswapLiquidity from './HoneyswapLiquidity'
 export const Screens = [
   { Screen: GardenTypeSelector, title: 'Type selection' },
   { Screen: GardenMetadata, title: 'Garden data' },
-  { Screen: HoneyswapLiquidity, title: 'HoneyswapLiquidity' },
+  { Screen: HoneyswapLiquidity, title: 'Honeyswap Liquidity' },
   { Screen: TokensSettings, title: 'Tokens settings' },
   { Screen: VotingSettings, title: 'Voting settings' },
-  { Screen: ConvictionVotingSettings, title: 'Conviction voting settings' },
+  { Screen: ConvictionVotingSettings, title: 'Conviction Voting settings' },
   { Screen: IssuanceSettings, title: 'Issuance settings' },
   { Screen: AgreementSettings, title: 'Covenant settings' },
 ]

--- a/src/components/Onboarding/Screens/config.js
+++ b/src/components/Onboarding/Screens/config.js
@@ -1,11 +1,13 @@
 import AgreementSettings from './Apps/AgreementSettings'
 import ConvictionVotingSettings from './Apps/ConvictionVotingSettings'
+import GardenMetadata from './GardenMetadata'
+import GardenTypeSelector from './GardenTypeSelector'
+import HoneyswapLiquidity from './HoneyswapLiquidity'
 import IssuanceSettings from './Apps/IssuanceSettings'
+import LaunchGarden from './LaunchGarden'
+import ReviewInformation from './ReviewInformation'
 import TokensSettings from './Apps/TokensSettings'
 import VotingSettings from './Apps/VotingSettings'
-import GardenTypeSelector from './GardenTypeSelector'
-import GardenMetadata from './GardenMetadata'
-import HoneyswapLiquidity from './HoneyswapLiquidity'
 
 export const Screens = [
   { Screen: GardenTypeSelector, title: 'Type selection' },
@@ -16,4 +18,6 @@ export const Screens = [
   { Screen: ConvictionVotingSettings, title: 'Conviction Voting settings' },
   { Screen: IssuanceSettings, title: 'Issuance settings' },
   { Screen: AgreementSettings, title: 'Covenant settings' },
+  { Screen: ReviewInformation, title: 'Review information' },
+  { Screen: LaunchGarden, title: 'Launch Garden' },
 ]

--- a/src/components/Onboarding/Screens/index.js
+++ b/src/components/Onboarding/Screens/index.js
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react'
+import { GU, springs } from '@1hive/1hive-ui'
+import { Transition, animated } from 'react-spring/renderprops'
+import { Screens } from './config'
+import { useOnboardingState } from '@providers/Onboarding'
+
+const AnimatedDiv = animated.div
+
+function OnboardingScreens() {
+  const [prevStep, setPrevStep] = useState(-1)
+  const { step } = useOnboardingState()
+
+  useEffect(() => {
+    setPrevStep(step)
+  }, [step])
+
+  const direction = step > prevStep ? 1 : -1
+  const { Screen, title } = Screens[step]
+
+  return (
+    <Transition
+      native
+      reset
+      unique
+      items={{ step, Screen }}
+      keys={({ step }) => step}
+      from={{
+        opacity: 0,
+        position: 'absolute',
+        transform: `translate3d(${10 * direction}%, 0, 0)`,
+      }}
+      enter={{
+        opacity: 1,
+        position: 'static',
+        transform: `translate3d(0%, 0, 0)`,
+      }}
+      leave={{
+        opacity: 0,
+        position: 'absolute',
+        transform: `translate3d(${-10 * direction}%, 0, 0)`,
+      }}
+      config={springs.smooth}
+    >
+      {({ Screen }) => ({ opacity, transform, position }) => (
+        <div
+          css={`
+            overflow: hidden;
+            position: relative;
+          `}
+        >
+          <AnimatedDiv
+            style={{ opacity, transform, position }}
+            css={`
+              top: 0;
+              left: 0;
+              right: 0;
+            `}
+          >
+            <div
+              css={`
+                margin-bottom: ${2 * GU}px;
+              `}
+            >
+              <Screen title={title} />
+            </div>
+          </AnimatedDiv>
+        </div>
+      )}
+    </Transition>
+  )
+}
+
+export default OnboardingScreens

--- a/src/components/Onboarding/Screens/index.js
+++ b/src/components/Onboarding/Screens/index.js
@@ -1,21 +1,20 @@
 import React, { useEffect, useState } from 'react'
 import { GU, springs } from '@1hive/1hive-ui'
 import { Transition, animated } from 'react-spring/renderprops'
-import { Screens } from './config'
 import { useOnboardingState } from '@providers/Onboarding'
 
 const AnimatedDiv = animated.div
 
 function OnboardingScreens() {
   const [prevStep, setPrevStep] = useState(-1)
-  const { step } = useOnboardingState()
+  const { step, steps } = useOnboardingState()
 
   useEffect(() => {
     setPrevStep(step)
   }, [step])
 
   const direction = step > prevStep ? 1 : -1
-  const { Screen, title } = Screens[step]
+  const { Screen, title } = steps[step]
 
   return (
     <Transition

--- a/src/components/Onboarding/Steps/StepsItem.js
+++ b/src/components/Onboarding/Steps/StepsItem.js
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react'
+import PropTypes from 'prop-types'
+import { GU, IconCheck, useTheme } from '@1hive/1hive-ui'
+
+function ConfigureStepsItem({ stepNumber, step, label, currentStep }) {
+  const theme = useTheme()
+
+  const stepStyles = useMemo(() => {
+    if (step === currentStep) {
+      return `
+        padding-top: 2px;
+        background: ${theme.selected};
+        color: ${theme.selectedContent};
+      `
+    }
+    if (step < currentStep) {
+      return `
+        background: ${theme.positive};
+        color: ${theme.positiveContent};
+      `
+    }
+    return `
+      padding-top: 2px;
+      background: #ECEFF4;
+      color: #9CA7B8;
+    `
+  }, [step, currentStep, theme])
+
+  return (
+    <div
+      css={`
+        display: flex;
+        align-items: center;
+        height: ${5 * GU}px;
+        & + & {
+          margin-top: ${3 * GU}px;
+        }
+      `}
+    >
+      <div
+        css={`
+          width: ${5 * GU}px;
+          height: ${5 * GU}px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 50%;
+          font-size: 18px;
+          font-weight: 600;
+          ${stepStyles};
+          flex-shrink: 0;
+          flex-grow: 0;
+        `}
+      >
+        {step < currentStep ? <IconCheck /> : stepNumber}
+      </div>
+      <div
+        css={`
+          margin-left: ${3 * GU}px;
+          font-size: 18px;
+          font-weight: ${step === currentStep ? '600' : '400'};
+          overflow: hidden;
+          text-overflow: ellipsis;
+        `}
+      >
+        {label}
+      </div>
+    </div>
+  )
+}
+
+ConfigureStepsItem.propTypes = {
+  currentStep: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+  step: PropTypes.number.isRequired,
+  stepNumber: PropTypes.number.isRequired,
+}
+
+export default ConfigureStepsItem

--- a/src/components/Onboarding/Steps/StepsPanel.js
+++ b/src/components/Onboarding/Steps/StepsPanel.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { CircleGraph, GU, useTheme } from '@1hive/1hive-ui'
+import StepsItem from './StepsItem'
+
+function StepsPanel({ step, steps }) {
+  const theme = useTheme()
+
+  return (
+    <aside
+      css={`
+        width: 100%;
+        min-height: 100%;
+        padding-top: ${10 * GU}px;
+        background: ${theme.surface};
+        border-right: 1px solid ${theme.border};
+      `}
+    >
+      <div
+        css={`
+          position: relative;
+          display: flex;
+          width: 100%;
+          justify-content: center;
+          height: ${25 * GU}px;
+        `}
+      >
+        <CircleGraph value={step / steps} size={25 * GU} />
+        <div
+          css={`
+            position: absolute;
+            top: 130px;
+            font-size: 20px;
+            color: #8e97b5;
+            opacity: 0.7;
+          `}
+        >
+          {`${step}/${steps}`}
+        </div>
+      </div>
+      <div
+        css={`
+          padding: ${8 * GU}px ${3 * GU}px ${3 * GU}px;
+        `}
+      >
+        {steps.map(
+          ([statusIndex, displayIndex, show], index) =>
+            show && (
+              <StepsItem
+                key={index}
+                currentStep={groupedSteps[step][0]}
+                label={steps[statusIndex]}
+                step={statusIndex}
+                stepNumber={displayIndex + 1}
+              />
+            )
+        )}
+      </div>
+    </aside>
+  )
+}
+
+StepsPanel.propTypes = {
+  step: PropTypes.number.isRequired,
+  steps: PropTypes.arrayOf(PropTypes.string).isRequired,
+}
+
+export default StepsPanel

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -52,17 +52,15 @@ function Onboarding({ onClose, visible }) {
           </div>
           <section
             css={`
-              display: flex;
-              flex-direction: column;
+              margin: 0px auto;
+              max-width: 800px;
+              padding: 0px 24px 48px;
             `}
           >
             <div
               css={`
                 display: flex;
                 flex-direction: column;
-                flex-grow: 1;
-                position: relative;
-                overflow: hidden;
               `}
             >
               <Screens />

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -1,13 +1,129 @@
 import React from 'react'
-import { OnboardingProvider } from '@providers/Onboarding'
+import { animated, Transition } from 'react-spring/renderprops'
+import { GU, IconCross, RootPortal, springs, useTheme } from '@1hive/1hive-ui'
+import { OnboardingProvider, useOnboardingState } from '@providers/Onboarding'
 import Screens from './Screens'
+import StepsPanel from './Steps/StepsPanel'
 
-function Onboarding() {
+function Onboarding({ onClose, visible }) {
+  const theme = useTheme()
+  const { step, steps } = useOnboardingState()
+
   return (
-    <OnboardingProvider>
-      <Screens />
-    </OnboardingProvider>
+    <AnimatedSlider visible={visible}>
+      <div
+        css={`
+          padding: ${3 * GU}px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+        `}
+      >
+        <div />
+        <div
+          css={`
+            cursor: pointer;
+          `}
+          onClick={onClose}
+        >
+          <IconCross color={theme.surfaceIcon} />
+        </div>
+      </div>
+      <div>
+        <div
+          css={`
+            width: ${41 * GU}px;
+            flex-shrink: 0;
+            flex-grow: 0;
+          `}
+        >
+          <StepsPanel step={step} steps={steps} />
+        </div>
+        <section
+          css={`
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            flex-grow: 1;
+            flex-shrink: 1;
+          `}
+        >
+          <div
+            css={`
+              display: flex;
+              flex-direction: column;
+              flex-grow: 1;
+              position: relative;
+              overflow: hidden;
+            `}
+          >
+            <Screens />
+          </div>
+        </section>
+      </div>
+    </AnimatedSlider>
   )
 }
 
-export default Onboarding
+function AnimatedSlider({ children, visible }) {
+  const theme = useTheme()
+  return (
+    <RootPortal>
+      <Transition
+        native
+        items={visible}
+        from={{ opacity: 0, transform: 'translateY(100%)' }}
+        enter={{ opacity: 1, transform: 'translateY(0%)' }}
+        leave={{ opacity: 0, transform: 'translateY(100%)' }}
+        config={{ ...springs.smooth, precision: 0.001 }}
+      >
+        {show =>
+          show &&
+          (({ opacity, transform }) => (
+            <div>
+              <animated.div
+                style={{
+                  position: 'fixed',
+                  opacity,
+                  top: '0',
+                  bottom: '0',
+                  left: '0',
+                  right: '0',
+                  zIndex: '4',
+                  background: theme.overlay.alpha(0.9),
+                }}
+              >
+                <animated.div
+                  style={{
+                    transform,
+                    position: 'fixed',
+                    bottom: '0',
+                    left: '0',
+                    right: '0',
+                    filter: 'drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.15))',
+                  }}
+                >
+                  <div
+                    css={`
+                      height: 100vh;
+                      background-color: ${theme.surface};
+                      border-top: 4px solid ${theme.accent};
+                    `}
+                  >
+                    {children}
+                  </div>
+                </animated.div>
+              </animated.div>
+            </div>
+          ))
+        }
+      </Transition>
+    </RootPortal>
+  )
+}
+
+export default () => (
+  <OnboardingProvider>
+    <Onboarding />
+  </OnboardingProvider>
+)

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -122,8 +122,8 @@ function AnimatedSlider({ children, visible }) {
   )
 }
 
-export default () => (
+export default ({ ...props }) => (
   <OnboardingProvider>
-    <Onboarding />
+    <Onboarding {...props} />
   </OnboardingProvider>
 )

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { OnboardingProvider } from '@providers/Onboarding'
+import Screens from './Screens'
+
+function Onboarding() {
+  return (
+    <OnboardingProvider>
+      <Screens />
+    </OnboardingProvider>
+  )
+}
+
+export default Onboarding

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -3,33 +3,19 @@ import { animated, Transition } from 'react-spring/renderprops'
 import { GU, IconCross, RootPortal, springs, useTheme } from '@1hive/1hive-ui'
 import { OnboardingProvider } from '@providers/Onboarding'
 import Screens from './Screens'
-// import StepsPanel from './Steps/StepsPanel'
+import StepsPanel from './Steps/StepsPanel'
 
 function Onboarding({ onClose, visible }) {
   const theme = useTheme()
-  // const { step, steps } = useOnboardingState()
 
   return (
     <AnimatedSlider visible={visible}>
       <div
         css={`
-          padding: ${3 * GU}px;
           display: flex;
-          align-items: center;
-          justify-content: space-between;
+          height: 100%;
         `}
       >
-        <div />
-        <div
-          css={`
-            cursor: pointer;
-          `}
-          onClick={onClose}
-        >
-          <IconCross color={theme.surfaceIcon} />
-        </div>
-      </div>
-      <div>
         <div
           css={`
             width: ${41 * GU}px;
@@ -37,12 +23,10 @@ function Onboarding({ onClose, visible }) {
             flex-grow: 0;
           `}
         >
-          {/* <StepsPanel step={step} steps={steps} /> */}
+          <StepsPanel />
         </div>
-        <section
+        <div
           css={`
-            display: flex;
-            flex-direction: column;
             width: 100%;
             flex-grow: 1;
             flex-shrink: 1;
@@ -50,16 +34,41 @@ function Onboarding({ onClose, visible }) {
         >
           <div
             css={`
+              padding: ${3 * GU}px;
               display: flex;
-              flex-direction: column;
-              flex-grow: 1;
-              position: relative;
-              overflow: hidden;
+              align-items: center;
+              justify-content: space-between;
             `}
           >
-            <Screens />
+            <div />
+            <div
+              css={`
+                cursor: pointer;
+              `}
+              onClick={onClose}
+            >
+              <IconCross color={theme.surfaceIcon} />
+            </div>
           </div>
-        </section>
+          <section
+            css={`
+              display: flex;
+              flex-direction: column;
+            `}
+          >
+            <div
+              css={`
+                display: flex;
+                flex-direction: column;
+                flex-grow: 1;
+                position: relative;
+                overflow: hidden;
+              `}
+            >
+              <Screens />
+            </div>
+          </section>
+        </div>
       </div>
     </AnimatedSlider>
   )

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import { animated, Transition } from 'react-spring/renderprops'
 import { GU, IconCross, RootPortal, springs, useTheme } from '@1hive/1hive-ui'
-import { OnboardingProvider, useOnboardingState } from '@providers/Onboarding'
+import { OnboardingProvider } from '@providers/Onboarding'
 import Screens from './Screens'
-import StepsPanel from './Steps/StepsPanel'
+// import StepsPanel from './Steps/StepsPanel'
 
 function Onboarding({ onClose, visible }) {
   const theme = useTheme()
-  const { step, steps } = useOnboardingState()
+  // const { step, steps } = useOnboardingState()
 
   return (
     <AnimatedSlider visible={visible}>
@@ -37,7 +37,7 @@ function Onboarding({ onClose, visible }) {
             flex-grow: 0;
           `}
         >
-          <StepsPanel step={step} steps={steps} />
+          {/* <StepsPanel step={step} steps={steps} /> */}
         </div>
         <section
           css={`

--- a/src/providers/Onboarding.js
+++ b/src/providers/Onboarding.js
@@ -1,10 +1,8 @@
 import React, { useCallback, useContext, useState } from 'react'
 import PropTypes from 'prop-types'
-import { Screens } from '@components/Onboarding/Screens/config'
+import { Screens as steps } from '@components/Onboarding/Screens/config'
 
 const OnboardingContext = React.createContext()
-
-const stepsLength = Screens.length
 
 const DEFAULT_CONFIG = {
   garden: {
@@ -83,7 +81,7 @@ function OnboardingProvider({ children }) {
   }, [])
 
   const handleNext = useCallback(() => {
-    setStep(index => Math.min(stepsLength - 1, index + 1))
+    setStep(index => Math.min(steps.length - 1, index + 1))
   }, [])
 
   return (
@@ -94,7 +92,7 @@ function OnboardingProvider({ children }) {
         onConfigChange: handleConfigChange,
         onNext: handleNext,
         step,
-        stepsLength,
+        steps,
       }}
     >
       {children}

--- a/src/providers/Onboarding.js
+++ b/src/providers/Onboarding.js
@@ -6,9 +6,78 @@ const OnboardingContext = React.createContext()
 
 const stepsLength = Screens.length
 
+const DEFAULT_CONFIG = {
+  garden: {
+    name: '',
+    description: '',
+    logo: null,
+    logotype: null,
+    forum: '',
+    links: {
+      documentation: [],
+      community: [],
+    },
+    type: null,
+  },
+  agreement: {
+    title: '',
+    content: '',
+    challengePeriod: 0,
+    actionAmount: 0,
+    challengeAmount: 0,
+    actionAmountsStable: [],
+    challengeAmountsStable: [],
+  },
+  conviction: {
+    decay: 0,
+    maxRatio: 0,
+    minThresholdStakePercentage: 0,
+    requestToken: '',
+    weight: 0,
+  },
+  issuance: {
+    maxAdjustmentRatioPerSecond: 0,
+    targetRatio: 0,
+  },
+  liquidity: {
+    honeyTokenLiquidityStable: 0,
+    tokenLiquidity: 0,
+  },
+  tokens: {
+    address: '', // Only used in BYOT
+    name: '',
+    symbol: '',
+    holders: [], // Only used in NATIVE
+    commonPool: 0, // Only used in NATIVE
+  },
+  voting: {
+    voteDuration: 0,
+    voteSupportRequired: 0,
+    voteMinAcceptanceQuorum: 0,
+    voteDelegatedVotingPeriod: 0,
+    voteQuietEndingPeriod: 0,
+    voteQuietEndingExtension: 0,
+    voteExecutionDelay: 0,
+  },
+}
+
 function OnboardingProvider({ children }) {
   const [step, setStep] = useState(0)
+  const [config, setConfig] = useState(DEFAULT_CONFIG)
 
+  const handleConfigChange = useCallback(
+    (key, data) =>
+      setConfig(config => ({
+        ...config,
+        [key]: {
+          ...config[key],
+          ...data,
+        },
+      })),
+    []
+  )
+
+  // Navigation
   const handleBack = useCallback(() => {
     setStep(index => Math.max(0, index - 1))
   }, [])
@@ -20,7 +89,9 @@ function OnboardingProvider({ children }) {
   return (
     <OnboardingContext.Provider
       value={{
+        config,
         onBack: handleBack,
+        onConfigChange: handleConfigChange,
         onNext: handleNext,
         step,
         stepsLength,

--- a/src/providers/Onboarding.js
+++ b/src/providers/Onboarding.js
@@ -1,16 +1,29 @@
-import React, { useContext, useState } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 import PropTypes from 'prop-types'
+import { Screens } from '@components/Onboarding/Screens/config'
 
 const OnboardingContext = React.createContext()
+
+const stepsLength = Screens.length
 
 function OnboardingProvider({ children }) {
   const [step, setStep] = useState(0)
 
+  const handleBack = useCallback(() => {
+    setStep(index => Math.max(0, index - 1))
+  }, [])
+
+  const handleNext = useCallback(() => {
+    setStep(index => Math.min(stepsLength - 1, index + 1))
+  }, [])
+
   return (
     <OnboardingContext.Provider
       value={{
+        onBack: handleBack,
+        onNext: handleNext,
         step,
-        setStep,
+        stepsLength,
       }}
     >
       {children}

--- a/src/providers/Onboarding.js
+++ b/src/providers/Onboarding.js
@@ -1,0 +1,29 @@
+import React, { useContext, useState } from 'react'
+import PropTypes from 'prop-types'
+
+const OnboardingContext = React.createContext()
+
+function OnboardingProvider({ children }) {
+  const [step, setStep] = useState(0)
+
+  return (
+    <OnboardingContext.Provider
+      value={{
+        step,
+        setStep,
+      }}
+    >
+      {children}
+    </OnboardingContext.Provider>
+  )
+}
+
+OnboardingProvider.propTypes = {
+  children: PropTypes.node,
+}
+
+function useOnboardingState() {
+  return useContext(OnboardingContext)
+}
+
+export { OnboardingProvider, useOnboardingState }

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import Garden from '@components/Garden'
 import Home from '@components/Home'
+import Onboarding from '@components/Onboarding'
 import Profile from '@components/Profile/Profile'
 
 export default function Routes() {
@@ -9,6 +10,7 @@ export default function Routes() {
     <Switch>
       <Redirect exact from="/" to="/home" />
       <Route path="/home" component={Home} />
+      <Route path="/create" component={Onboarding} />
       <Route exact path="/profile" component={Profile} />
       <Route path="/garden/:daoId" component={Garden} />
       <Redirect to="/home" />

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import Garden from '@components/Garden'
 import Home from '@components/Home'
-import Onboarding from '@components/Onboarding'
 import Profile from '@components/Profile/Profile'
 
 export default function Routes() {
@@ -10,7 +9,6 @@ export default function Routes() {
     <Switch>
       <Redirect exact from="/" to="/home" />
       <Route path="/home" component={Home} />
-      <Route path="/create" component={Onboarding} />
       <Route exact path="/profile" component={Profile} />
       <Route path="/garden/:daoId" component={Garden} />
       <Redirect to="/home" />


### PR DESCRIPTION
closes https://github.com/1Hive/gardens/issues/154

Includes: 

- Basic component for all screens involved with navigation.
- Progress sidebar
- Onboarding provider with basic logic (next step, back step, updating config data)
  It should be noted when implementing a screen that when submitting the form with all the inputs the data should be saved in the provider using `onConfigChange` like so: 

	 ```
	 onConfigChange(key, data)
	 ```
	  
	   where key is the respective key set in the default config (see Onboarding.js)

