### PR TITLE
Onboarding: Add Voting Settings Screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
     "react-spring": "^8.0.27",
+    "react-use-gesture": "5.2.4",
     "react-use-intercom": "^1.2.0",
     "react-use-measure": "^2.0.1",
     "styled-components": "^4.3.2",

--- a/src/components/Onboarding/Screens/Apps/VotingSettings.js
+++ b/src/components/Onboarding/Screens/Apps/VotingSettings.js
@@ -1,19 +1,265 @@
-import React from 'react'
+import React, {
+  Fragment,
+  useCallback,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
+import { GU, Help } from '@1hive/1hive-ui'
 import { useOnboardingState } from '@providers/Onboarding'
 import Navigation from '../../Navigation'
+import {
+  TimeParameterPanel,
+  Header,
+  PercentageField,
+  Carousel,
+} from '../../kit'
+import { DAY_IN_SECONDS } from '@/utils/kit-utils'
+
+const DEFAULT_SUPPORT = 50
+const DEFAULT_MIN_ACCEPTANCE_QUORUM = 10
+const DEFAULT_DURATION = DAY_IN_SECONDS * 5
+const DEFAULT_DELEGATED_VOTING_PERIOD = DAY_IN_SECONDS * 2
+const DEFAULT_QUITE_ENDING_PERIOD = DAY_IN_SECONDS * 1
+const DEFAULT_QUITE_ENDING_EXTENSION_PERIOD = DAY_IN_SECONDS * 0.5
+const DEFAULT_EXECUTION_DELAY_PERIOD = DAY_IN_SECONDS * 1
+
+const reduceFields = (fields, [field, value]) => {
+  switch (field) {
+    case 'support':
+      return {
+        ...fields,
+        support: value,
+        quorum: Math.min(fields.quorum, value),
+      }
+    case 'quorum':
+      return {
+        ...fields,
+        quorum: value,
+        support: Math.max(fields.support, value),
+      }
+    case 'duration':
+      return {
+        ...fields,
+        duration: value,
+      }
+    case 'delegatedVotingPeriod':
+      return {
+        ...fields,
+        delegatedVotingPeriod: value,
+      }
+    case 'quiteEndingPeriod':
+      return {
+        ...fields,
+        quiteEndingPeriod: value,
+      }
+    case 'quiteEndingExtensionPeriod':
+      return {
+        ...fields,
+        quiteEndingExtensionPeriod: value,
+      }
+    case 'executionDelayPeriod':
+      return {
+        ...fields,
+        executionDelayPeriod: value,
+      }
+    default:
+      return fields
+  }
+}
 
 function VotingSettings() {
-  const { onBack, onNext } = useOnboardingState()
+  const [isLastItemChecked, setIsLastItemChecked] = useState(false)
+  const { onBack, onNext, onConfigChange } = useOnboardingState()
+  const [
+    {
+      support,
+      quorum,
+      duration,
+      delegatedVotingPeriod,
+      quiteEndingPeriod,
+      quiteEndingExtensionPeriod,
+      executionDelayPeriod,
+    },
+    updateField,
+  ] = useReducer(reduceFields, {
+    support: DEFAULT_SUPPORT,
+    quorum: DEFAULT_MIN_ACCEPTANCE_QUORUM,
+    duration: DEFAULT_DURATION,
+    delegatedVotingPeriod: DEFAULT_DELEGATED_VOTING_PERIOD,
+    quiteEndingPeriod: DEFAULT_QUITE_ENDING_PERIOD,
+    quiteEndingExtensionPeriod: DEFAULT_QUITE_ENDING_EXTENSION_PERIOD,
+    executionDelayPeriod: DEFAULT_EXECUTION_DELAY_PERIOD,
+  })
+  const supportRef = useRef()
+
+  const handleSupportRef = useCallback(ref => {
+    supportRef.current = ref
+    if (ref) {
+      ref.focus()
+    }
+  }, [])
+
+  const handleSupportChange = useCallback(
+    value => {
+      updateField(['support', value])
+    },
+    [updateField]
+  )
+
+  const handleQuorumChange = useCallback(
+    value => {
+      updateField(['quorum', value])
+    },
+    [updateField]
+  )
+
+  const handleDurationChange = useCallback(
+    value => {
+      updateField(['duration', value])
+    },
+    [updateField]
+  )
+
+  const handleDelegatedVotingPeriodChange = useCallback(
+    value => {
+      updateField(['delegatedVotingPeriod', value])
+    },
+    [updateField]
+  )
+  const handleQuiteEndingPeriodChange = useCallback(
+    value => {
+      updateField(['quiteEndingPeriod', value])
+    },
+    [updateField]
+  )
+
+  const handleQuiteEndingExtensionPeriodChange = useCallback(
+    value => {
+      updateField(['quiteEndingExtensionPeriod', value])
+    },
+    [updateField]
+  )
+
+  const handleExecutionDelayPeriodChange = useCallback(
+    value => {
+      updateField(['executionDelayPeriod', value])
+    },
+    [updateField]
+  )
+
+  const handleNextClick = () => {
+    onConfigChange('voting', {
+      voteDuration: duration,
+      voteSupportRequired: support,
+      voteMinAcceptanceQuorum: quorum,
+      voteDelegatedVotingPeriod: delegatedVotingPeriod,
+      voteQuietEndingPeriod: quiteEndingPeriod,
+      voteQuietEndingExtension: quiteEndingExtensionPeriod,
+      voteExecutionDelay: executionDelayPeriod,
+    })
+    onNext()
+  }
+
+  const carouselItems = [
+    <TimeParameterPanel
+      title="Voting Duration"
+      description="Vote duration is the length of time that the vote will be open for participation. For example, if the Vote Duration is set to 24 hours, then tokenholders have 24 hours to participate in the vote."
+      value={duration}
+      onUpdate={handleDurationChange}
+    />,
+    <TimeParameterPanel
+      title="Delegate Voting Period"
+      description="Delegate voting period is the duration from the start of a vote that representatives are allowed to vote on behalf of principals."
+      value={delegatedVotingPeriod}
+      onUpdate={handleDelegatedVotingPeriodChange}
+    />,
+    <TimeParameterPanel
+      title="Quite Ending Period"
+      description="Quite ending period is the duration before the end of a vote to detect non-quiet endings. Non-quiet endings are endings which involve a late swing in the vote."
+      value={quiteEndingPeriod}
+      onUpdate={handleQuiteEndingPeriodChange}
+    />,
+    <TimeParameterPanel
+      title="Quite Ending Extension Period"
+      description="Quite ending extension period is the duration to extend a vote in the case of a non-quiet ending."
+      value={quiteEndingExtensionPeriod}
+      onUpdate={handleQuiteEndingExtensionPeriodChange}
+    />,
+    <TimeParameterPanel
+      title="Delay Period"
+      description="Delay period is the duration to wait before a passed vote can be executed. This allows people to react to the outcome and make decisions before the effects of the vote are realised."
+      value={executionDelayPeriod}
+      onUpdate={handleExecutionDelayPeriodChange}
+    />,
+  ]
+
+  const handleItemSelected = useCallback(
+    index => {
+      if (index === carouselItems.length - 1) {
+        setIsLastItemChecked(true)
+      }
+    },
+    [carouselItems.length]
+  )
 
   return (
     <div>
-      VotingSettings
+      <Header
+        title="Configure Community Voting"
+        subtitle="Choose your settings below"
+      />
+      <PercentageField
+        ref={handleSupportRef}
+        label={
+          <Fragment>
+            Support %{' '}
+            <Help hint="What is Support?">
+              <strong>Support</strong> is the relative percentage of tokens that
+              are required to vote “Yes” for a proposal to be approved. For
+              example, if “Support” is set to 50%, then more than 50% of the
+              tokens used to vote on a proposal must vote “Yes” for it to pass.
+            </Help>
+          </Fragment>
+        }
+        value={support}
+        onChange={handleSupportChange}
+      />
+      <PercentageField
+        label={
+          <Fragment>
+            Minimum Approval %
+            <Help hint="What is Minimum Approval?">
+              <strong>Minimum Approval</strong> is the percentage of the total
+              token supply that is required to vote “Yes” on a proposal before
+              it can be approved. For example, if the “Minimum Approval” is set
+              to 20%, then more than 20% of the outstanding token supply must
+              vote “Yes” on a proposal for it to pass.
+            </Help>
+          </Fragment>
+        }
+        value={quorum}
+        onChange={handleQuorumChange}
+      />
+      <div
+        css={`
+          margin-bottom: ${7 * GU}px;
+        `}
+      >
+        <Carousel
+          itemWidth={80 * GU}
+          itemHeight={40 * GU}
+          itemSpacing={2 * GU}
+          items={carouselItems}
+          onItemSelected={handleItemSelected}
+        />
+      </div>
       <Navigation
         backEnabled
-        nextEnabled
+        nextEnabled={isLastItemChecked}
         nextLabel="Next:"
         onBack={onBack}
-        onNext={onNext}
+        onNext={handleNextClick}
       />
     </div>
   )

--- a/src/components/Onboarding/kit/Carousel/Carousel.js
+++ b/src/components/Onboarding/kit/Carousel/Carousel.js
@@ -1,0 +1,200 @@
+import React, { useCallback, useEffect, useState, useRef } from 'react'
+import PropTypes from 'prop-types'
+import { GU, useViewport, unselectable, springs } from '@1hive/1hive-ui'
+import { animated, useSpring } from 'react-spring'
+import { useDrag } from 'react-use-gesture'
+import PrevNext from './PrevNext'
+
+// TODO:
+//  - Center the items when the total is smaller than the viewport.
+
+const AnimatedDiv = animated.div
+
+function Carousel({
+  items,
+  itemWidth,
+  itemHeight,
+  itemSpacing,
+  onItemSelected = () => {},
+}) {
+  const [selected, setSelected] = useState(0)
+  const [containerWidth, setContainerWidth] = useState(0)
+  const [visibleItems, setVisibleItems] = useState(0)
+  const container = useRef(null)
+  const { width: vw } = useViewport()
+
+  useEffect(() => {
+    onItemSelected(selected)
+  }, [onItemSelected, selected])
+
+  // Set the number of visible items,
+  // and adjust the selected item if needed.
+  useEffect(() => {
+    const visibleItems = Math.max(
+      1,
+      Math.floor((containerWidth - itemSpacing * 2) / (itemWidth + itemSpacing))
+    )
+    const lastSelectionableItem = items.length - visibleItems
+
+    setVisibleItems(visibleItems)
+    setSelected(selected =>
+      selected > lastSelectionableItem ? lastSelectionableItem : selected
+    )
+  }, [containerWidth, itemSpacing, itemWidth, items])
+
+  const updateContainerWidth = useCallback(element => {
+    setContainerWidth(element ? element.clientWidth : 0)
+  }, [])
+
+  useEffect(() => {
+    if (container.current) {
+      updateContainerWidth(container.current)
+    }
+  }, [vw, updateContainerWidth])
+
+  const handleContainerRef = useCallback(
+    element => {
+      container.current = element
+      updateContainerWidth(element)
+    },
+    [updateContainerWidth]
+  )
+
+  const prev = useCallback(() => {
+    setSelected(selected => Math.max(0, selected - visibleItems))
+  }, [visibleItems])
+
+  const next = useCallback(() => {
+    setSelected(selected =>
+      Math.min(items.length - visibleItems, selected + visibleItems)
+    )
+  }, [items.length, visibleItems])
+
+  // The total width of the visible items
+  const visibleItemsWidth =
+    visibleItems * itemWidth + (visibleItems - 1) * itemSpacing
+
+  // The space on one side of the visible items
+  const sideSpace = (containerWidth - visibleItemsWidth) / 2
+
+  // Get the container x position from an item index
+  const xFromItem = useCallback(
+    index => sideSpace - (itemWidth + itemSpacing) * index,
+    [sideSpace, itemWidth, itemSpacing]
+  )
+
+  // The current x position, before the drag
+  const selectedX = xFromItem(selected)
+
+  // The x position of the last item, before the drag
+  const lastX = xFromItem(items.length - visibleItems)
+
+  // Handles the actual x position, with the drag
+  const [{ x, drag }, setX] = useSpring(() => ({
+    x: selectedX,
+    config: springs.lazy,
+    drag: Number(false),
+    immediate: true,
+  }))
+
+  // Update the transition during drag
+  const bindDrag = useDrag(({ down, delta }) => {
+    const updatedX = Math.max(lastX, Math.min(sideSpace, selectedX + delta[0]))
+
+    if (down) {
+      setX({
+        x: updatedX,
+        immediate: true,
+      })
+    } else {
+      let target = selected
+      if (Math.abs(delta[0]) > itemWidth / 2) {
+        if (delta[0] > 0) {
+          target = Math.max(0, selected - 1)
+        } else {
+          target = Math.min(selected + 1, items.length - 1)
+        }
+      }
+
+      setX({
+        x: xFromItem(target),
+        immediate: false,
+      })
+      setSelected(target)
+    }
+  })
+
+  // Update the transition when the base x position updates
+  useEffect(() => {
+    setX({
+      x: selectedX,
+      immediate: false,
+    })
+  }, [selectedX, setX])
+
+  return (
+    <div
+      ref={handleContainerRef}
+      css={`
+        ${unselectable};
+        position: relative;
+        overflow: hidden;
+        width: 100%;
+        height: ${itemHeight}px;
+        touch-action: none;
+      `}
+    >
+      {selected > 0 && <PrevNext type="previous" onClick={prev} />}
+      {selected < items.length - visibleItems && (
+        <PrevNext type="next" onClick={next} />
+      )}
+      <AnimatedDiv
+        {...bindDrag()}
+        style={{
+          transform: x.interpolate(x => `translate3d(${(0, x)}px, 0, 0)`),
+        }}
+        css={`
+          display: flex;
+          height: 100%;
+          position: absolute;
+          touch-action: none;
+        `}
+      >
+        {items.map((item, i) => (
+          <AnimatedDiv
+            key={i}
+            style={{
+              opacity: drag.interpolate(drag => {
+                return drag || (i >= selected && i < selected + visibleItems)
+                  ? 1
+                  : 0.25
+              }),
+            }}
+            css={`
+              flex-grow: 0;
+              flex-shrink: 0;
+              width: ${itemWidth}px;
+              height: ${itemHeight}px;
+              transition: opacity 150ms ease-in-out;
+              & + & {
+                margin-left: ${3 * GU}px;
+              }
+            `}
+          >
+            {item}
+          </AnimatedDiv>
+        ))}
+      </AnimatedDiv>
+    </div>
+  )
+}
+
+Carousel.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.node).isRequired,
+  itemWidth: PropTypes.number.isRequired,
+  itemHeight: PropTypes.number.isRequired,
+  itemSpacing: PropTypes.number.isRequired,
+  onItemSelected: PropTypes.func,
+}
+
+export default Carousel

--- a/src/components/Onboarding/kit/Carousel/PrevNext.js
+++ b/src/components/Onboarding/kit/Carousel/PrevNext.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { GU, ButtonIcon, IconRight, IconLeft } from '@1hive/1hive-ui'
+
+function PrevNext({ onClick, type }) {
+  const next = type === 'next'
+  const Icon = next ? IconRight : IconLeft
+
+  return (
+    <ButtonIcon
+      onClick={onClick}
+      label={next ? 'Next' : 'Previous'}
+      css={`
+        position: absolute;
+        z-index: 1;
+        top: calc(50% - ${3 * GU}px);
+        height: ${6 * GU}px;
+        ${next ? 'right' : 'left'}: ${5 * GU}px;
+      `}
+    >
+      <Icon size="large" />
+    </ButtonIcon>
+  )
+}
+
+PrevNext.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  type: PropTypes.oneOf(['next', 'previous']).isRequired,
+}
+
+export default PrevNext

--- a/src/components/Onboarding/kit/DurationFields.js
+++ b/src/components/Onboarding/kit/DurationFields.js
@@ -1,0 +1,137 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import PropTypes from 'prop-types'
+import { Field, GU, TextInput, useTheme, useViewport } from '@1hive/1hive-ui'
+import {
+  DAY_IN_SECONDS,
+  HOUR_IN_SECONDS,
+  MINUTE_IN_SECONDS,
+} from '@/utils/kit-utils'
+
+const DurationFields = ({ duration, onUpdate, label, direction = 'row' }) => {
+  const theme = useTheme()
+  const { above } = useViewport()
+  const isRow = direction === 'row'
+
+  // Calculate the units based on the initial duration (in seconds).
+  const [baseDays, baseHours, baseMinutes] = useMemo(() => {
+    let remaining = duration
+
+    const days = Math.floor(remaining / DAY_IN_SECONDS)
+    remaining -= days * DAY_IN_SECONDS
+
+    const hours = Math.floor(remaining / HOUR_IN_SECONDS)
+    remaining -= hours * HOUR_IN_SECONDS
+
+    const minutes = Math.floor(remaining / MINUTE_IN_SECONDS)
+    remaining -= minutes * MINUTE_IN_SECONDS
+
+    return [days, hours, minutes]
+  }, [duration])
+
+  // Local units state − updated from the initial duration if needed.
+  const [minutes, setMinutes] = useState(baseMinutes)
+  const [hours, setHours] = useState(baseHours)
+  const [days, setDays] = useState(baseDays)
+
+  // If any of the units change, call onUpdate() with the updated duration,
+  // so that it can get updated if the “next” button gets pressed.
+  useEffect(() => {
+    onUpdate(
+      minutes * MINUTE_IN_SECONDS +
+        hours * HOUR_IN_SECONDS +
+        days * DAY_IN_SECONDS
+    )
+  }, [onUpdate, minutes, hours, days])
+
+  // Invoked by handleDaysChange etc. to update a local unit.
+  const updateLocalUnit = useCallback((event, stateSetter) => {
+    const value = Number(event.target.value)
+    if (!isNaN(value)) {
+      stateSetter(value)
+    }
+  }, [])
+
+  const handleDaysChange = useCallback(
+    event => updateLocalUnit(event, setDays),
+    [updateLocalUnit]
+  )
+  const handleHoursChange = useCallback(
+    event => updateLocalUnit(event, setHours),
+    [updateLocalUnit]
+  )
+  const handleMinutesChange = useCallback(
+    event => updateLocalUnit(event, setMinutes),
+    [updateLocalUnit]
+  )
+
+  return (
+    <Field label={label}>
+      {({ id }) => (
+        <div
+          css={`
+            display: flex;
+            padding-top: ${0.5 * GU}px;
+            flex-direction: ${direction};
+            width: 100%;
+          `}
+        >
+          {[
+            ['Days', handleDaysChange, days],
+            ['Hours', handleHoursChange, hours],
+            [
+              above('medium') ? 'Minutes' : 'Min.',
+              handleMinutesChange,
+              minutes,
+            ],
+          ].map(([label, handler, value], index) => (
+            <div
+              key={label}
+              css={`
+                flex-grow: 1;
+                // max-width: ${17 * GU}px;
+                & + & {
+                  margin-${isRow ? 'left' : 'top'}: ${2 * GU}px;
+                }
+              `}
+            >
+              <TextInput
+                id={index === 0 ? id : undefined}
+                adornment={
+                  <span
+                    css={`
+                      padding: 0 ${1.5 * GU}px;
+                      color: ${theme.contentSecondary};
+                    `}
+                  >
+                    {label}
+                  </span>
+                }
+                adornmentPosition="end"
+                adornmentSettings={{
+                  width: 8 * GU,
+                  padding: 0,
+                }}
+                onChange={handler}
+                value={value}
+                wide
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </Field>
+  )
+}
+
+DurationFields.propTypes = {
+  duration: PropTypes.number,
+  label: PropTypes.node,
+  onUpdate: PropTypes.func.isRequired,
+}
+
+DurationFields.defaultProps = {
+  duration: 0,
+  label: '',
+}
+
+export default DurationFields

--- a/src/components/Onboarding/kit/Header.js
+++ b/src/components/Onboarding/kit/Header.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { textStyle, useTheme, GU } from '@1hive/1hive-ui'
+
+function Header({
+  title,
+  subtitle,
+  topSpacing = 10 * GU,
+  bottomSpacing = 7 * GU,
+}) {
+  const theme = useTheme()
+  return (
+    <header
+      css={`
+        padding: ${topSpacing}px ${2 * GU}px ${bottomSpacing}px;
+        text-align: center;
+      `}
+    >
+      <h1
+        css={`
+          // Not in aragonUI - exceptionally used here
+          font-size: 40px;
+          font-weight: 600;
+          padding-bottom: ${subtitle ? 2 * GU : 0}px;
+        `}
+      >
+        {title}
+      </h1>
+      {subtitle && (
+        <div
+          css={`
+            ${textStyle('title4')};
+            color: ${theme.contentSecondary};
+          `}
+        >
+          {subtitle}
+        </div>
+      )}
+    </header>
+  )
+}
+
+Header.propTypes = {
+  title: PropTypes.node.isRequired,
+  subtitle: PropTypes.node,
+  topSpacing: PropTypes.number.isRequired,
+  bottomSpacing: PropTypes.number.isRequired,
+}
+
+Header.defaultProps = {
+  topSpacing: 10 * GU,
+  bottomSpacing: 7 * GU,
+}
+
+export default Header

--- a/src/components/Onboarding/kit/PercentageField.js
+++ b/src/components/Onboarding/kit/PercentageField.js
@@ -1,0 +1,136 @@
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+import PropTypes from 'prop-types'
+import {
+  Field,
+  GU,
+  Slider,
+  TextInput,
+  textStyle,
+  useTheme,
+} from '@1hive/1hive-ui'
+
+const PercentageField = React.forwardRef(function PercentageField(
+  { label, value, onChange },
+  ref
+) {
+  const theme = useTheme()
+  const inputRef = useRef()
+  const [textFieldValue, setTextFieldValue] = useState(value)
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => {
+        if (inputRef.current) {
+          inputRef.current.focus()
+        }
+      },
+      element: inputRef.current,
+    }),
+    []
+  )
+
+  useEffect(() => {
+    setTextFieldValue(value)
+  }, [value])
+
+  const handleSliderChange = useCallback(
+    v => {
+      onChange(Math.round(v * 100))
+    },
+    [onChange]
+  )
+
+  const handleInputChange = useCallback(event => {
+    const value = parseInt(event.target.value, 10)
+    if (!isNaN(value) && value >= 0 && value <= 100) {
+      setTextFieldValue(value)
+    }
+  }, [])
+
+  const handleInputBlur = useCallback(
+    event => {
+      onChange(textFieldValue)
+    },
+    [onChange, textFieldValue]
+  )
+
+  return (
+    <Field label={label}>
+      {({ id }) => (
+        <div
+          css={`
+            display: flex;
+            flex-direction: row;
+          `}
+        >
+          <Slider
+            value={value / 100}
+            onUpdate={handleSliderChange}
+            css={`
+              flex-grow: 1;
+              padding-left: 0;
+              padding-right: 0;
+              margin-right: ${3 * GU}px;
+              min-width: ${20 * GU}px;
+            `}
+          />
+          <div
+            css={`
+              position: relative;
+              flex-grow: 0;
+              flex-shrink: 0;
+              width: ${8 * GU}px;
+            `}
+          >
+            <TextInput
+              ref={inputRef}
+              id={id}
+              value={textFieldValue}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              wide
+              css={`
+                padding-right: ${3.5 * GU}px;
+                text-align: right;
+              `}
+            />
+            <span
+              css={`
+                position: absolute;
+                top: 0;
+                right: ${1.5 * GU}px;
+                bottom: 0;
+                display: flex;
+                align-items: center;
+                ${textStyle('body3')};
+                color: ${theme.surfaceContent};
+                pointer-events: none;
+              `}
+            >
+              %
+            </span>
+          </div>
+        </div>
+      )}
+    </Field>
+  )
+})
+
+PercentageField.defaultProps = {
+  label: 'Percentage',
+}
+
+PercentageField.propTypes = {
+  label: PropTypes.node,
+  value: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+}
+
+export default PercentageField

--- a/src/components/Onboarding/kit/TimeParameterPanel.js
+++ b/src/components/Onboarding/kit/TimeParameterPanel.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { Box, GU, textStyle } from '@1hive/1hive-ui'
+import { DurationFields } from '.'
+
+const TimeParameterPanel = ({ title, description, value, onUpdate }) => {
+  return (
+    <div
+      css={`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: ${GU * 4}px;
+      `}
+    >
+      <Box
+        css={`
+          width: 60%;
+          margin-right: ${GU * 6}px;
+        `}
+      >
+        <div
+          css={`
+            ${textStyle('title3')};
+            margin-bottom: ${GU}px;
+          `}
+        >
+          {title}
+        </div>
+        <div>{description}</div>
+      </Box>
+
+      <div
+        css={`
+          width: 24%;
+        `}
+      >
+        <DurationFields
+          duration={value}
+          onUpdate={onUpdate}
+          direction="column"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default TimeParameterPanel

--- a/src/components/Onboarding/kit/index.js
+++ b/src/components/Onboarding/kit/index.js
@@ -1,0 +1,5 @@
+export { default as Header } from './Header'
+export { default as PercentageField } from './PercentageField'
+export { default as TimeParameterPanel } from './TimeParameterPanel'
+export { default as DurationFields } from './DurationFields'
+export { default as Carousel } from './Carousel/Carousel'

--- a/src/utils/kit-utils.js
+++ b/src/utils/kit-utils.js
@@ -1,0 +1,3 @@
+export const MINUTE_IN_SECONDS = 60
+export const HOUR_IN_SECONDS = MINUTE_IN_SECONDS * 60
+export const DAY_IN_SECONDS = HOUR_IN_SECONDS * 24

--- a/yarn.lock
+++ b/yarn.lock
@@ -17649,6 +17649,11 @@ react-spring@^8.0.27:
     "@babel/runtime" "^7.3.1"
     prop-types "^15.5.8"
 
+react-use-gesture@5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-5.2.4.tgz#c84ebe0d79703fd90cb26a220812c2f430d3e40d"
+  integrity sha512-oay95IPKBTAIqsZWwPAXJVVlDCpXdg4y2kEKz8oGLSqewpmXsXC4vKlAZq/ZDwZa4djzWlK1pnSIJY2iylx4QQ==
+
 react-use-intercom@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-use-intercom/-/react-use-intercom-1.2.0.tgz#d0958f16bf82caa422d7b8bb3530077d674445a1"


### PR DESCRIPTION
This PR implements the `<VotingSettings/>` screen for the gardens onboarding. 

It also includes a series of common components inside the `Onboarding/kit` folder that can be reused  in other onboarding screens.

![pr](https://user-images.githubusercontent.com/33203511/123192155-a13f4200-d4a2-11eb-91e3-9bee5b9570c7.gif)
