### PR TITLE
Onboarding: Add TokensSettings Screen

### DIFF
--- a/src/components/Onboarding/Screens/Apps/TokensSettings.js
+++ b/src/components/Onboarding/Screens/Apps/TokensSettings.js
@@ -1,21 +1,16 @@
 import React from 'react'
-import { useOnboardingState } from '@providers/Onboarding'
-import Navigation from '../../Navigation'
+import { useOnboardingState } from '../../../../providers/Onboarding'
+import { NATIVE_TYPE, BYOT_TYPE } from '../../constants'
+import TokensSettingsNative from './TokensSettingsNative'
+import TokensSettingsBYOT from './TokensSettingsBYOT'
 
-function TokensSettings({ title }) {
-  const { onBack, onNext, step, steps } = useOnboardingState()
-
+function TokensSettings() {
+  const { config } = useOnboardingState()
   return (
-    <div>
-      {title}
-      <Navigation
-        backEnabled
-        nextEnabled
-        nextLabel={`Next: ${steps[step + 1].title}`}
-        onBack={onBack}
-        onNext={onNext}
-      />
-    </div>
+    <>
+      {config.garden.type === NATIVE_TYPE && <TokensSettingsNative />}
+      {config.garden.type === BYOT_TYPE && <TokensSettingsBYOT />}
+    </>
   )
 }
 

--- a/src/components/Onboarding/Screens/Apps/TokensSettingsBYOT.js
+++ b/src/components/Onboarding/Screens/Apps/TokensSettingsBYOT.js
@@ -1,0 +1,282 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  Field,
+  GU,
+  Help,
+  Info,
+  IconCheck,
+  IconCross,
+  isAddress,
+  LoadingRing,
+  TextInput,
+  theme,
+} from '@1hive/1hive-ui'
+import Navigation from '../../Navigation'
+import { useOnboardingState } from '@providers/Onboarding'
+import { useTokenData } from '@hooks/useToken'
+import Header from '../../kit/Header'
+
+function useFieldsLayout() {
+  return `
+    display: grid;
+    grid-template-columns: auto ${21 * GU}px;
+    grid-column-gap: ${1.5 * GU}px;
+  `
+}
+function validationError(tokenAddress, tokenName, tokenSymbol) {
+  if (!tokenAddress) {
+    return 'Please, provide a token address'
+  }
+  if (!isAddress(tokenAddress)) {
+    return 'The token address you provided is invalid.'
+  }
+  if (!tokenName.trim()) {
+    return 'Please add a token name.'
+  }
+  if (!tokenSymbol) {
+    return 'Please add a token symbol.'
+  }
+  return null
+}
+
+function TokensSettingsBYOT() {
+  const fieldsLayout = useFieldsLayout()
+
+  const {
+    config,
+    onBack,
+    onConfigChange,
+    onNext,
+    steps,
+    step,
+  } = useOnboardingState()
+
+  const [formError, setFormError] = useState(null)
+  const [tokenAddress, setTokenAddress] = useState(config.tokens.address)
+  const [tokenData, loadingTokenData, tokenDataError] = useTokenData(
+    isAddress(tokenAddress) && tokenAddress
+  )
+  const [gTokenName, setGTokenName] = useState(config.tokens.name)
+  const [gTokenSymbol, setGTokenSymbol] = useState(config.tokens.symbol)
+
+  const handleTokenAddressChange = useCallback(event => {
+    setFormError(null)
+    setTokenAddress(event.target.value)
+  }, [])
+  const handleTokenNameChange = useCallback(event => {
+    setFormError(null)
+    setGTokenName(event.target.value)
+  }, [])
+  const handleTokenSymbolChange = useCallback(event => {
+    setFormError(null)
+    setGTokenSymbol(event.target.value.trim().toUpperCase())
+  }, [])
+
+  const handleNext = useCallback(
+    event => {
+      event.preventDefault()
+
+      const error = validationError(tokenAddress, gTokenName, gTokenSymbol)
+      setFormError(error)
+
+      if (!error) {
+        onConfigChange('tokens', {
+          address: tokenAddress,
+          name: gTokenName,
+          symbol: gTokenSymbol,
+        })
+        onNext()
+      }
+    },
+    [onNext, tokenAddress, gTokenName, gTokenSymbol, onConfigChange]
+  )
+
+  useEffect(() => {
+    if (
+      isAddress(tokenAddress) &&
+      !tokenDataError &&
+      tokenData.name &&
+      tokenData.symbol &&
+      !loadingTokenData
+    ) {
+      setGTokenName(`Garden ${tokenData.name}`)
+      setGTokenSymbol(`g${tokenData.symbol}`)
+    } else {
+      setGTokenName('')
+      setGTokenSymbol('')
+    }
+  }, [tokenData, loadingTokenData, tokenAddress, tokenDataError])
+
+  return (
+    <form
+      css={`
+        display: grid;
+        align-items: center;
+        justify-content: center;
+      `}
+    >
+      <div
+        css={`
+          width: 752px;
+        `}
+      >
+        <Header
+          title="Configure Garden Token"
+          subtitle={<span>Choose your settings below.</span>}
+        />
+        <div
+          css={`
+            ${fieldsLayout};
+          `}
+        >
+          <Field
+            label={
+              <React.Fragment>
+                Token address
+                <Help hint="What is Token Address?">
+                  <strong>Token Address</strong> is the address of the token you
+                  want to bring to the garden.
+                </Help>
+              </React.Fragment>
+            }
+          >
+            {({ id }) => (
+              <TextInput
+                id={id}
+                onChange={handleTokenAddressChange}
+                placeholder="Token Address"
+                value={tokenAddress}
+                wide
+              />
+            )}
+          </Field>
+          <div
+            css={`
+              display: flex;
+              margin: auto auto auto ${2 * GU}px;
+            `}
+          >
+            {loadingTokenData && (
+              <LoadingRing
+                mode="half-circle"
+                css={`
+                  & > svg {
+                    height: ${2 * GU}px;
+                    width: ${2 * GU}px;
+                `}
+              />
+            )}
+
+            {!tokenDataError &&
+              gTokenSymbol &&
+              gTokenName &&
+              !loadingTokenData && <IconCheck color={theme.positive} />}
+
+            {tokenDataError && !loadingTokenData && isAddress(tokenAddress) && (
+              <IconCross color={theme.negative} />
+            )}
+          </div>
+
+          <Field
+            label={
+              <React.Fragment>
+                Garden Token Name
+                <Help hint="What is Token Name?">
+                  <strong>Garden Token Name</strong> is the name you can assign
+                  to the token you are bringing to this garden.
+                </Help>
+              </React.Fragment>
+            }
+          >
+            {({ id }) => (
+              <TextInput
+                id={id}
+                onChange={handleTokenNameChange}
+                placeholder="Garden Token Name"
+                value={gTokenName}
+                disabled={!gTokenName}
+                wide
+              />
+            )}
+          </Field>
+
+          <Field
+            label={
+              <React.Fragment>
+                Garden Token Symbol
+                <Help hint="What is Token Symbol?">
+                  <strong>Garden Token Symbol</strong> or ticker is a shortened
+                  name (typically in capital letters) that refers to a token or
+                  coin on a trading platform. For example: HNY.
+                </Help>
+              </React.Fragment>
+            }
+          >
+            {({ id }) => (
+              <TextInput
+                id={id}
+                onChange={handleTokenSymbolChange}
+                value={gTokenSymbol}
+                placeholder="MCT"
+                disabled={!gTokenSymbol}
+                wide
+              />
+            )}
+          </Field>
+        </div>
+      </div>
+
+      {formError && (
+        <Info
+          mode="error"
+          css={`
+            margin-bottom: ${3 * GU}px;
+          `}
+        >
+          {formError}
+        </Info>
+      )}
+      {gTokenName && gTokenSymbol && (
+        <Info
+          mode="warning"
+          css={`
+            margin-bottom: ${3 * GU}px;
+          `}
+        >
+          We recommend sticking with the default syntax here unless you have a
+          good reason not to.
+        </Info>
+      )}
+
+      {isAddress(tokenAddress) && tokenDataError && (
+        <Info
+          mode="error"
+          css={`
+            margin-bottom: ${3 * GU}px;
+          `}
+        >
+          The address you provided does not match with a token contract.
+        </Info>
+      )}
+
+      <Info
+        css={`
+          margin-bottom: ${3 * GU}px;
+        `}
+      >
+        These settings will determine the name and symbol of your community
+        token. Add the address of the token you want to bring to your Garden.
+      </Info>
+
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel={`Next: ${steps[step + 1].title}`}
+        onBack={onBack}
+        onNext={handleNext}
+      />
+    </form>
+  )
+}
+
+export default TokensSettingsBYOT

--- a/src/components/Onboarding/Screens/Apps/TokensSettingsNative.js
+++ b/src/components/Onboarding/Screens/Apps/TokensSettingsNative.js
@@ -1,0 +1,417 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Button,
+  EthIdenticon,
+  Field,
+  GU,
+  Help,
+  IconPlus,
+  IconTrash,
+  Info,
+  isAddress,
+  RADIUS,
+  TextInput,
+  useTheme,
+} from '@1hive/1hive-ui'
+import Navigation from '../../Navigation'
+import { useOnboardingState } from '@providers/Onboarding'
+import Header from '../../kit/Header'
+
+function useFieldsLayout() {
+  return `
+    display: grid;
+    grid-template-columns: auto ${14.5 * GU}px;
+    grid-column-gap: ${1.5 * GU}px;
+  `
+}
+
+function validateDuplicateAddresses(members) {
+  const validAddresses = members
+    .map(([address]) => address.toLowerCase())
+    .filter(address => isAddress(address))
+
+  return validAddresses.length === new Set(validAddresses).size
+}
+
+function validationError(tokenName, tokenSymbol, members) {
+  if (members.some(([address]) => !isAddress(address))) {
+    return 'Every address you provide should be a valid address.'
+  }
+  if (members.some(([account, stake]) => !(stake > 0))) {
+    return 'Every account has to have a positive balance.'
+  }
+  if (!validateDuplicateAddresses(members)) {
+    return 'One of your members is using the same address than another member. Please ensure every member address is unique.'
+  }
+  if (!tokenName.trim()) {
+    return 'Please add a token name.'
+  }
+  if (!tokenSymbol) {
+    return 'Please add a token symbol.'
+  }
+  return null
+}
+
+function TokensSettingsNative() {
+  const theme = useTheme()
+  const fieldsLayout = useFieldsLayout()
+
+  const {
+    config,
+    onBack,
+    onNext,
+    steps,
+    step,
+    onConfigChange,
+  } = useOnboardingState()
+
+  const [formError, setFormError] = useState()
+
+  const [tokenName, setTokenName] = useState(config.tokens.name)
+  const [tokenSymbol, setTokenSymbol] = useState(config.tokens.symbol)
+
+  const [members, setMembers] = useState(
+    config.tokens.holders.length === 0 ? [['', 0]] : config.tokens.holders
+  )
+
+  const handleTokenNameChange = useCallback(event => {
+    setFormError(null)
+    setTokenName(event.target.value)
+  }, [])
+
+  const handleTokenSymbolChange = useCallback(event => {
+    setFormError(null)
+    setTokenSymbol(event.target.value.trim().toUpperCase())
+  }, [])
+
+  const membersRef = useRef()
+  const [focusLastMemberNext, setFocusLastMemberNext] = useState(false)
+
+  useEffect(() => {
+    if (!focusLastMemberNext || !membersRef.current) {
+      return
+    }
+
+    setFocusLastMemberNext(false)
+
+    // This could be managed in individual MemberField components, but using
+    // the container with a .member class makes it simpler to manage, since we
+    // want to focus in three cases:
+    //   - A new field is being added.
+    //   - A field is being removed.
+    //   - The first field is being emptied.
+    //
+    const elts = membersRef.current.querySelectorAll('.member')
+    if (elts.length > 0) {
+      elts[elts.length - 1].querySelector('input').focus()
+    }
+  }, [focusLastMemberNext])
+
+  const focusLastMember = useCallback(() => {
+    setFocusLastMemberNext(true)
+  }, [])
+
+  const addMember = useCallback(() => {
+    setFormError(null)
+    setMembers(members => [...members, ['', 0]])
+    focusLastMember()
+  }, [focusLastMember])
+
+  const removeMember = useCallback(
+    index => {
+      setFormError(null)
+      setMembers(members =>
+        members.length < 2
+          ? // When the remove button of the last field
+            // gets clicked, we only empty the field.
+            [['', 0]]
+          : members.filter((_, i) => i !== index)
+      )
+      focusLastMember()
+    },
+    [focusLastMember]
+  )
+
+  const updateMember = useCallback((index, updatedAccount, updatedStake) => {
+    setFormError(null)
+    setMembers(members =>
+      members.map((member, i) =>
+        i === index ? [updatedAccount, updatedStake] : member
+      )
+    )
+  }, [])
+
+  const handleNext = useCallback(
+    event => {
+      event.preventDefault()
+
+      const error = validationError(tokenName, tokenSymbol, members)
+      setFormError(error)
+
+      if (!error) {
+        onConfigChange('tokens', {
+          name: tokenName,
+          symbol: tokenSymbol,
+          holders: members,
+        })
+        onNext()
+      }
+    },
+    [members, onNext, tokenName, tokenSymbol, onConfigChange]
+  )
+
+  const hideRemoveButton = members.length < 2 && !members[0]
+
+  return (
+    <form
+      css={`
+        display: grid;
+        align-items: center;
+        justify-content: center;
+      `}
+    >
+      <div>
+        <Header
+          title="Configure Garden Token"
+          subtitle={<span>Choose your settings below.</span>}
+        />
+
+        <div
+          css={`
+            ${fieldsLayout};
+          `}
+        >
+          <Field
+            label={
+              <React.Fragment>
+                Token name
+                <Help hint="What is Token Name?">
+                  <strong>Token Name</strong> is the name you can assign to the
+                  token that will be minted when creating this garden.
+                </Help>
+              </React.Fragment>
+            }
+          >
+            {({ id }) => (
+              <TextInput
+                id={id}
+                onChange={handleTokenNameChange}
+                placeholder="My Community Token"
+                value={tokenName}
+                wide
+              />
+            )}
+          </Field>
+
+          <Field
+            label={
+              <React.Fragment>
+                Token symbol
+                <Help hint="What is Token Symbol?">
+                  <strong>Token Symbol</strong> or ticker is a shortened name
+                  (typically in capital letters) that refers to a token or coin
+                  on a trading platform. For example: HNY.
+                </Help>
+              </React.Fragment>
+            }
+          >
+            {({ id }) => (
+              <TextInput
+                id={id}
+                onChange={handleTokenSymbolChange}
+                value={tokenSymbol}
+                placeholder="MCT"
+                wide
+              />
+            )}
+          </Field>
+        </div>
+      </div>
+      <Field
+        label={
+          <div
+            css={`
+              width: 100%;
+              ${fieldsLayout}
+            `}
+          >
+            <div>Seed holders 🌱</div>
+            <div>Balances</div>
+          </div>
+        }
+      >
+        <div ref={membersRef}>
+          {members.map((member, index) => (
+            <MemberField
+              key={index}
+              index={index}
+              member={member}
+              onRemove={removeMember}
+              hideRemoveButton={hideRemoveButton}
+              onUpdate={updateMember}
+              displayStake
+            />
+          ))}
+        </div>
+        <Button
+          icon={
+            <IconPlus
+              css={`
+                color: ${theme.accent};
+              `}
+            />
+          }
+          label="Add more"
+          onClick={addMember}
+        />
+      </Field>
+      {formError && (
+        <Info
+          mode="error"
+          css={`
+            margin-bottom: ${3 * GU}px;
+          `}
+        >
+          {formError}
+        </Info>
+      )}
+
+      <Info
+        css={`
+          margin-bottom: ${3 * GU}px;
+        `}
+      >
+        These settings will determine the name and symbol of the token that will
+        be created for your community. Add seed members to define the initial
+        distribution of this token.
+      </Info>
+
+      <Navigation
+        backEnabled
+        nextEnabled
+        nextLabel={`Next: ${steps[step + 1].title}`}
+        onBack={onBack}
+        onNext={handleNext}
+      />
+    </form>
+  )
+}
+
+function MemberField({
+  index,
+  member,
+  hideRemoveButton,
+  onUpdate,
+  onRemove,
+  displayStake,
+}) {
+  const theme = useTheme()
+  const fieldsLayout = useFieldsLayout()
+
+  const [account, stake] = member
+
+  const handleRemove = useCallback(() => {
+    onRemove(index)
+  }, [onRemove, index])
+
+  const handleAccountChange = useCallback(
+    event => {
+      onUpdate(index, event.target.value, stake)
+    },
+    [onUpdate, stake, index]
+  )
+
+  const handleStakeChange = useCallback(
+    event => {
+      const value = parseInt(event.target.value, 10)
+      onUpdate(index, account, isNaN(value) ? -1 : value)
+    },
+    [onUpdate, account, index]
+  )
+
+  return (
+    <div
+      className="member"
+      css={`
+        ${fieldsLayout};
+        position: relative;
+        margin-bottom: ${1.5 * GU}px;
+      `}
+    >
+      <div>
+        <TextInput
+          adornment={
+            <span css="transform: translateY(1px)">
+              {!hideRemoveButton && (
+                <Button
+                  display="icon"
+                  icon={
+                    <IconTrash
+                      css={`
+                        color: ${theme.negative};
+                      `}
+                    />
+                  }
+                  label="Remove"
+                  onClick={handleRemove}
+                  size="mini"
+                />
+              )}
+            </span>
+          }
+          adornmentPosition="end"
+          adornmentSettings={{ width: 52, padding: 8 }}
+          onChange={handleAccountChange}
+          placeholder="Ethereum address"
+          value={account}
+          wide
+          css={`
+            padding-left: ${4.5 * GU}px;
+          `}
+        />
+        <div
+          css={`
+            position: absolute;
+            top: ${1 * GU}px;
+            left: ${1 * GU}px;
+          `}
+        >
+          {isAddress(account) ? (
+            <EthIdenticon address={account} radius={RADIUS} />
+          ) : (
+            <div
+              css={`
+                width: ${3 * GU}px;
+                height: ${3 * GU}px;
+                background: ${theme.disabled};
+                border-radius: ${RADIUS}px;
+              `}
+            />
+          )}
+        </div>
+      </div>
+      <div>
+        {displayStake && (
+          <TextInput
+            onChange={handleStakeChange}
+            value={stake === -1 ? '' : stake}
+            wide
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+MemberField.propTypes = {
+  hideRemoveButton: PropTypes.bool.isRequired,
+  index: PropTypes.number.isRequired,
+  member: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ).isRequired,
+  onRemove: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+}
+
+export default TokensSettingsNative

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -22,25 +22,43 @@ export function useTokenBalanceOf(tokenAddress, account) {
 }
 
 export function useTokenData(tokenAddress) {
-  const [tokenData, setTokenData] = useState({ decimals: 18, symbol: '' })
-  const [loading, setLoading] = useState(true)
+  const [tokenData, setTokenData] = useState({
+    name: '',
+    decimals: 18,
+    symbol: '',
+  })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
 
   const mounted = useMounted()
   const tokenContract = useContractReadOnly(tokenAddress, tokenAbi)
 
   useEffect(() => {
     const fetchTokenData = async () => {
-      const decimals = await tokenContract.decimals()
-      const symbol = await tokenContract.symbol()
-
-      if (mounted()) {
-        setTokenData({ decimals, symbol })
+      if (tokenAddress) {
+        setError(null)
+        setTokenData({ name: '', decimals: 18, symbol: '' })
+        setLoading(true)
+      }
+      try {
+        const name = await tokenContract.name()
+        const symbol = await tokenContract.symbol()
+        const decimals = await tokenContract.decimals()
+        if (mounted()) {
+          setTokenData({ name, decimals, symbol })
+          setLoading(false)
+        }
+      } catch (error) {
         setLoading(false)
+        setError(error)
       }
     }
 
+    if (!tokenContract) {
+      return
+    }
     fetchTokenData()
-  }, [mounted, tokenContract])
+  }, [mounted, tokenContract, tokenAddress])
 
-  return [tokenData, loading]
+  return [tokenData, loading, error]
 }


### PR DESCRIPTION
This PR contains the TokensSettings screen for the Onboarding, it consists in:

- A folder with the Tokens icon for the Header.
- The Header component used in every wizard screen.
- The KnownAppBadge component to display the icons in the Header.
- The TokenSettings main screen.
     - The TokensSettingsNative screen that displays when the user selects "Native" when choosing Garden Type.
     - The TokensSettingsBYOT screen that displays when the user selects "BYOT" when choosing Garden Type.

- Adding changes to the useToken hook to fetch the token symbol, set loading only when an address is provided and treat an exception.  