### PR TITLE
Chore: fix vscode webpack aliases resolution

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"],
+      "@abis/*": ["abi/*"],
+      "@assets/*": ["assets/*"],
+      "@components/*": ["components/*"],
+      "@hooks/*": ["hooks/*"],
+      "@lib/*": ["lib/*"],
+      "@providers/*": ["providers/*"],
+      "@utils/*": ["utils/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
With the addition of webpack aliases (`@/*`, `@abi/*`, etc), we need to give more context to the IDE to understand the new resolution of modules. 

This PR includes a `jsconfig.json` file as explained in vscode documentation: https://code.visualstudio.com/docs/languages/jsconfig