### PR TITLE
Style: onboarding logo and background style

### DIFF
--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { animated, Transition } from 'react-spring/renderprops'
 import { GU, IconCross, RootPortal, springs, useTheme } from '@1hive/1hive-ui'
+import gardensLogo from '@assets/gardensLogoMark.svg'
 import { OnboardingProvider } from '@providers/Onboarding'
 import { ChartsProvider } from '@providers/Charts'
 import Screens from './Screens'
@@ -24,6 +25,16 @@ function Onboarding({ onClose, visible }) {
             flex-grow: 0;
           `}
         >
+          <img
+            css={`
+              display: flex;
+              padding-left: 18px;
+              margin-top: 17px;
+            `}
+            src={gardensLogo}
+            height={32}
+            alt=""
+          />
           <StepsPanel />
         </div>
         <div
@@ -31,6 +42,7 @@ function Onboarding({ onClose, visible }) {
             width: 100%;
             flex-grow: 1;
             flex-shrink: 1;
+            background: #f9f9f8;
           `}
         >
           <div


### PR DESCRIPTION
Use designs background style for the onboarding and add gardens logo mark.

<img width="1708" alt="Screen Shot 2021-08-07 at 5 52 33 PM" src="https://user-images.githubusercontent.com/9082013/128613598-02b51a97-cff1-4bf1-9654-2bf1553f2f58.png">
