### PR TITLE
Fix(hooks): useAgreement

### DIFF
--- a/src/hooks/useAgreement.js
+++ b/src/hooks/useAgreement.js
@@ -19,6 +19,10 @@ export function useAgreement() {
   const [initialProcessing, setInitialProcessing] = useState(true)
 
   useEffect(() => {
+    if (!apps) {
+      return
+    }
+    
     async function processAgreementDetails() {
       const {
         currentVersion,

--- a/src/hooks/useAgreement.js
+++ b/src/hooks/useAgreement.js
@@ -22,7 +22,7 @@ export function useAgreement() {
     if (!apps) {
       return
     }
-    
+
     async function processAgreementDetails() {
       const {
         currentVersion,


### PR DESCRIPTION
- [x] Fix https://github.com/1Hive/gardens/issues/282

Prevent the App to raise an error with: `Unhandled Rejection (TypeError): Cannot read property 'find' of undefined` because the app object is not defined yet.

