### PR TITLE
UX: fix celeste link

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -99,7 +99,7 @@ function Header() {
                       color: ${theme.contentSecondary};
                     `}
                   >
-                    Be A Keeper Of Celeste
+                    Become a Keeper
                   </Link>
                 )}
               </nav>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -91,16 +91,17 @@ function Header() {
                 `}
               >
                 {connectedGarden && <GardenNavItems garden={connectedGarden} />}
-                <Link
-                  href={network.celesteUrl}
-                  css={`
-                    text-decoration: none;
-                    color: ${theme.contentSecondary};
-                    margin-left: ${(connectedGarden ? 4 : 0) * GU}px;
-                  `}
-                >
-                  Stake Honey
-                </Link>
+                {!connectedGarden && (
+                  <Link
+                    href={network.celesteUrl}
+                    css={`
+                      text-decoration: none;
+                      color: ${theme.contentSecondary};
+                    `}
+                  >
+                    Be A Keeper Of Celeste
+                  </Link>
+                )}
               </nav>
             )}
           </div>


### PR DESCRIPTION
- Fix https://github.com/1Hive/gardens/issues/135

Remove the Stake Honey link from every Garden home page.
Update description of the link name to make it more understandable.