### PR TITLE
Change support - UX fixes

### DIFF
--- a/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
@@ -42,9 +42,7 @@ const ChangeSupport = React.memo(function ChangeSupport({
 
   const totalStaked = useAccountTotalStaked(account)
   const nonStakedTokens = token.accountBalance.minus(totalStaked)
-  console.log('token and account balance')
-  console.log(token)
-  console.log(account)
+
   const myStake = useMemo(
     () =>
       stakes.find(({ supporter }) =>
@@ -202,11 +200,12 @@ const ChangeSupport = React.memo(function ChangeSupport({
       >
         You have staked{' '}
         <strong>
-          {myStake.amount.c / 10000} {stakeToken.symbol}
+          {formatTokenAmount(myStake.amount, stakeToken.decimals)}{' '}
+          {stakeToken.symbol}
         </strong>{' '}
-        on this proposal. You have an additional{' '}
+        on this proposal. You can stake up to{' '}
         <strong>
-          {formatTokenAmount(nonStakedTokens, stakeToken.decimals)}{' '}
+          {formatTokenAmount(maxAvailable, stakeToken.decimals)}{' '}
           {stakeToken.symbol}
         </strong>{' '}
         ({nonStakedPct}% of your balance) available to support this proposal.{' '}

--- a/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
@@ -200,7 +200,7 @@ const ChangeSupport = React.memo(function ChangeSupport({
         `}
       >
         You have staked {myStake.amount.c / 10000} {stakeToken.symbol} on this
-        proposal. You have a total of{' '}
+        proposal. You have an additional{' '}
         <strong>
           {formatTokenAmount(nonStakedTokens, stakeToken.decimals)}{' '}
           {stakeToken.symbol}

--- a/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
@@ -199,7 +199,8 @@ const ChangeSupport = React.memo(function ChangeSupport({
           margin-top: ${2 * GU}px;
         `}
       >
-        You have{' '}
+        You have staked {myStake.amount.c / 10000} {stakeToken.symbol} on this
+        proposal. You have a total of{' '}
         <strong>
           {formatTokenAmount(nonStakedTokens, stakeToken.decimals)}{' '}
           {stakeToken.symbol}

--- a/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
@@ -41,7 +41,7 @@ const ChangeSupport = React.memo(function ChangeSupport({
   const { stakes } = proposal
 
   const totalStaked = useAccountTotalStaked(account)
-  const nonStakedTokens = token.accountBalance.minus(totalStaked)
+  // const nonStakedTokens = token.accountBalance.minus(totalStaked)
 
   const myStake = useMemo(
     () =>
@@ -57,6 +57,8 @@ const ChangeSupport = React.memo(function ChangeSupport({
     () => token.accountBalance.minus(totalStaked).plus(myStake.amount),
     [myStake.amount, token.accountBalance, totalStaked]
   )
+
+  const totalStakedOnOthers = totalStaked - myStake.amount
 
   useEffect(() => {
     if (myStake.amount) {
@@ -145,8 +147,10 @@ const ChangeSupport = React.memo(function ChangeSupport({
   }, [amount, maxAvailable])
 
   // Calculate percentages
-  const nonStakedPct = round(pct(nonStakedTokens, token.accountBalance))
-  const stakedPct = round(100 - nonStakedPct)
+  // const nonStakedPct = round(pct(nonStakedTokens, token.accountBalance))
+  // const stakedPct = round(100 - nonStakedPct)
+  const maxStakedPct = round(pct(maxAvailable, token.accountBalance))
+  const stakedOthersPct = round(pct(totalStakedOnOthers, token.accountBalance))
 
   return (
     <form onSubmit={handleSubmit}>
@@ -198,27 +202,27 @@ const ChangeSupport = React.memo(function ChangeSupport({
           margin-top: ${2 * GU}px;
         `}
       >
-        You have staked{' '}
+        You are currently supporting this proposal with{' '}
         <strong>
           {formatTokenAmount(myStake.amount, stakeToken.decimals)}{' '}
           {stakeToken.symbol}
         </strong>{' '}
-        on this proposal. You can stake up to{' '}
+        . You have up to{' '}
         <strong>
           {formatTokenAmount(maxAvailable, stakeToken.decimals)}{' '}
           {stakeToken.symbol}
         </strong>{' '}
-        ({nonStakedPct}% of your balance) available to support this proposal.{' '}
-        {totalStaked.gt(0) === false && (
+        ({maxStakedPct}% of your balance) available to support this proposal.{' '}
+        {
           <span>
             You are supporting other proposals with{' '}
             <strong>
-              {formatTokenAmount(totalStaked, stakeToken.decimals)}{' '}
+              {formatTokenAmount(totalStakedOnOthers, stakeToken.decimals)}{' '}
               {stakeToken.symbol}
             </strong>{' '}
-            ({stakedPct}% of your balance).
+            ({stakedOthersPct}% of your balance).
           </span>
-        )}
+        }
       </Info>
       <Button
         css={`

--- a/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
@@ -1,14 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import {
-  Button,
-  ButtonBase,
-  GU,
-  Field,
-  Info,
-  TextInput,
-  textStyle,
-  useTheme,
-} from '@1hive/1hive-ui'
+import { Button, ButtonBase, GU, Field, Info, TextInput } from '@1hive/1hive-ui'
 
 import useAccountTotalStaked from '@hooks/useAccountTotalStaked'
 import { useGardenState } from '@providers/GardenState'
@@ -26,8 +17,6 @@ const ChangeSupport = React.memo(function ChangeSupport({
   proposal,
   getTransactions,
 }) {
-  const theme = useTheme()
-
   const { account } = useWallet()
   const { config, token } = useGardenState()
   const { stakeToken } = config.conviction
@@ -154,14 +143,6 @@ const ChangeSupport = React.memo(function ChangeSupport({
 
   return (
     <form onSubmit={handleSubmit}>
-      <h3
-        css={`
-          ${textStyle('body3')}
-        `}
-      >
-        This action modifies the amount of tokens staked on this proposal. Your
-        stake will progressively increase from 0 up to the amount specified.
-      </h3>
       <Field
         label="amount"
         css={`
@@ -177,7 +158,7 @@ const ChangeSupport = React.memo(function ChangeSupport({
             <ButtonBase
               css={`
                 margin-right: ${1 * GU}px;
-                color: ${theme.accent};
+                color: #30db9e;
               `}
               onClick={handleMaxSelected}
             >
@@ -206,7 +187,7 @@ const ChangeSupport = React.memo(function ChangeSupport({
         <strong>
           {formatTokenAmount(myStake.amount, stakeToken.decimals)}{' '}
           {stakeToken.symbol}
-        </strong>{' '}
+        </strong>
         . You have up to{' '}
         <strong>
           {formatTokenAmount(maxAvailable, stakeToken.decimals)}{' '}

--- a/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
@@ -30,7 +30,6 @@ const ChangeSupport = React.memo(function ChangeSupport({
   const { stakes } = proposal
 
   const totalStaked = useAccountTotalStaked(account)
-  // const nonStakedTokens = token.accountBalance.minus(totalStaked)
 
   const myStake = useMemo(
     () =>
@@ -136,8 +135,6 @@ const ChangeSupport = React.memo(function ChangeSupport({
   }, [amount, maxAvailable])
 
   // Calculate percentages
-  // const nonStakedPct = round(pct(nonStakedTokens, token.accountBalance))
-  // const stakedPct = round(100 - nonStakedPct)
   const maxStakedPct = round(pct(maxAvailable, token.accountBalance))
   const stakedOthersPct = round(pct(totalStakedOnOthers, token.accountBalance))
 

--- a/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/ChangeSupport.js
@@ -42,7 +42,9 @@ const ChangeSupport = React.memo(function ChangeSupport({
 
   const totalStaked = useAccountTotalStaked(account)
   const nonStakedTokens = token.accountBalance.minus(totalStaked)
-
+  console.log('token and account balance')
+  console.log(token)
+  console.log(account)
   const myStake = useMemo(
     () =>
       stakes.find(({ supporter }) =>
@@ -155,9 +157,8 @@ const ChangeSupport = React.memo(function ChangeSupport({
           ${textStyle('body3')}
         `}
       >
-        This action will modify the amount of tokens locked with this proposal.
-        The token weight backing the proposal will increase over time from 0 up
-        to the amount specified.
+        This action modifies the amount of tokens staked on this proposal. Your
+        stake will progressively increase from 0 up to the amount specified.
       </h3>
       <Field
         label="amount"
@@ -199,8 +200,11 @@ const ChangeSupport = React.memo(function ChangeSupport({
           margin-top: ${2 * GU}px;
         `}
       >
-        You have staked {myStake.amount.c / 10000} {stakeToken.symbol} on this
-        proposal. You have an additional{' '}
+        You have staked{' '}
+        <strong>
+          {myStake.amount.c / 10000} {stakeToken.symbol}
+        </strong>{' '}
+        on this proposal. You have an additional{' '}
         <strong>
           {formatTokenAmount(nonStakedTokens, stakeToken.decimals)}{' '}
           {stakeToken.symbol}

--- a/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useCallback } from 'react'
 import { Button } from '@1hive/1hive-ui'
 import { useHistory } from 'react-router'
+import { buildGardenPath } from '@utils/routing-utils'
 import ModalFlowBase from '../ModalFlowBase'
 import ChangeSupport from './ChangeSupport'
 import SupportProposal from './SupportProposal'
@@ -20,7 +21,7 @@ function SupportProposalScreens({ proposal, mode }) {
   }, [history])
 
   const handleViewHome = useCallback(() => {
-    const path = '/home'
+    const path = buildGardenPath(history.location, 'home')
     history.push(path)
   }, [history])
 

--- a/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
@@ -14,24 +14,51 @@ function SupportProposalScreens({ proposal, mode }) {
 
   const { id: proposalId } = proposal
 
-  const handleViewProposal = useCallback(() => {
+  const handleViewProposals = useCallback(() => {
     const path = '/profile'
+    history.push(path)
+  }, [history])
+
+  const handleViewHome = useCallback(() => {
+    const path = '/home'
     history.push(path)
   }, [history])
 
   const renderOnCompleteActions = useCallback(() => {
     if (mode === 'support' ? 'Support this proposal' : 'Change support') {
       return (
-        <Button
-          label="View supported proposals"
-          mode="strong"
-          onClick={handleViewProposal}
-          wide
-        />
+        <div
+          css={`
+            text-align: center;
+          `}
+        >
+          <Button
+            label="Supported proposals"
+            mode="strong"
+            onClick={handleViewProposals}
+            wide
+            css={`
+              width: 40%;
+              display: inline;
+              margin-right: 0.5rem;
+            `}
+          />
+          <Button
+            label="Home"
+            mode="strong"
+            onClick={handleViewHome}
+            wide
+            css={`
+              width: 40%;
+              display: inline;
+              margin-left: 0.5rem;
+            `}
+          />
+        </div>
       )
     }
     return null
-  }, [handleViewProposal, mode])
+  }, [handleViewProposals, mode])
 
   const getTransactions = useCallback(
     async (onComplete, amount) => {

--- a/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
@@ -1,4 +1,6 @@
 import React, { useMemo, useState, useCallback } from 'react'
+import { Button } from '@1hive/1hive-ui'
+import { useHistory } from 'react-router'
 import ModalFlowBase from '../ModalFlowBase'
 import ChangeSupport from './ChangeSupport'
 import SupportProposal from './SupportProposal'
@@ -6,10 +8,30 @@ import SupportProposal from './SupportProposal'
 import useActions from '@hooks/useActions'
 
 function SupportProposalScreens({ proposal, mode }) {
+  const history = useHistory()
   const [transactions, setTransactions] = useState([])
   const { convictionActions } = useActions()
 
   const { id: proposalId } = proposal
+
+  const handleViewProposal = useCallback(() => {
+    const path = '/profile'
+    history.push(path)
+  }, [history])
+
+  const renderOnCompleteActions = useCallback(() => {
+    if (mode === 'support' ? 'Support this proposal' : 'Change support') {
+      return (
+        <Button
+          label="View supported proposals"
+          mode="strong"
+          onClick={handleViewProposal}
+          wide
+        />
+      )
+    }
+    return null
+  }, [handleViewProposal, mode])
 
   const getTransactions = useCallback(
     async (onComplete, amount) => {
@@ -82,6 +104,7 @@ function SupportProposalScreens({ proposal, mode }) {
         mode === 'support' ? 'Support this proposal' : 'Change support'
       }
       screens={screens}
+      onCompleteActions={renderOnCompleteActions}
     />
   )
 }

--- a/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
@@ -59,7 +59,7 @@ function SupportProposalScreens({ proposal, mode }) {
       )
     }
     return null
-  }, [handleViewProposals, mode])
+  }, [handleViewHome, handleViewProposals, mode])
 
   const getTransactions = useCallback(
     async (onComplete, amount) => {


### PR DESCRIPTION
Addresses  
- [x] https://github.com/1Hive/gardens/issues/265: option to choose between `home` view and `supported proposals` (profile) view
- [x] https://github.com/1Hive/gardens/issues/300: remove confusing language around actions and staking; make it clear how much you are already supporting the proposal with, how much you can support it with, and how much support you are giving to other proposals
![Screenshot 2021-08-22 at 16 15 53](https://user-images.githubusercontent.com/5483559/130358404-b236ba0d-68e8-4c83-9a39-146cabbd8cbb.png)

- [x] https://github.com/1Hive/gardens/issues/262#issuecomment-901406191: make `MAX` button greener (same colour as `Proposal Status`)
