### PR TITLE
Footer: Add default 'Gardens' footer

### DIFF
--- a/src/components/Garden/Footer.js
+++ b/src/components/Garden/Footer.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useHistory } from 'react-router'
 import {
   ButtonBase,
@@ -24,19 +24,61 @@ import createSvg from '@assets/create.svg'
 import defaultGardenLogo from '@assets/defaultGardenLogo.png'
 import getHoneySvg from '@assets/getHoney.svg' // TODO: Update
 import gardenSvg from '@assets/gardensLogoMark.svg'
+import gardensLogoType from '@assets/gardensLogoType.svg'
+
+const defaultFooterData = {
+  links: {
+    community: [
+      {
+        label: 'Discord',
+        link: 'https://discord.gg/4fm7pgB',
+      },
+      {
+        label: 'Github',
+        link: 'https://github.com/1hive/gardens',
+      },
+      {
+        label: 'Twitter',
+        link: 'https://twitter.com/gardensdao',
+      },
+      {
+        label: 'Website',
+        link: 'https://gardens.1hive.org/',
+      },
+    ],
+    documentation: [
+      {
+        label: 'Gitbook',
+        link: 'https://1hive.gitbook.io/gardens',
+      },
+    ],
+  },
+  logo: gardensLogoType,
+  garden: false,
+}
 
 function Footer() {
   const theme = useTheme()
   const { below } = useViewport()
   const compactMode = below('large')
+  const [footerData, setFooterData] = useState(defaultFooterData)
 
   const { connectedGarden } = useGardens()
-  if (!connectedGarden) {
-    return null
-  }
 
-  const { links, logo, token, wrappableToken } = connectedGarden
-  const logoSvg = logo || defaultGardenLogo
+  useEffect(() => {
+    if (connectedGarden) {
+      const { links, logo, token, wrappableToken } = connectedGarden
+      setFooterData({
+        links,
+        logo,
+        token,
+        wrappableToken,
+        garden: true,
+      })
+    }
+  }, [connectedGarden])
+
+  const logoSvg = footerData.logo || defaultGardenLogo
 
   return (
     <footer
@@ -49,7 +91,11 @@ function Footer() {
     >
       <Layout paddingBottom={40}>
         {compactMode ? (
-          <FixedFooter token={wrappableToken || token} />
+          footerData.garden && (
+            <FixedFooter
+              token={footerData.wrappableToken || footerData.token}
+            />
+          )
         ) : (
           <div
             css={`
@@ -63,9 +109,13 @@ function Footer() {
             `}
           >
             <div>
-              <img src={logoSvg} height="60" alt="" />
+              <img
+                src={logoSvg}
+                height={footerData.garden ? '60' : '40'}
+                alt=""
+              />
             </div>
-            {links?.community && (
+            {footerData.links?.community && (
               <div>
                 <h5
                   css={`
@@ -75,7 +125,7 @@ function Footer() {
                 >
                   Community
                 </h5>
-                {links.community.map((link, i) => {
+                {footerData.links.community.map((link, i) => {
                   return (
                     <Link key={i} href={link.link} external>
                       {link.label}
@@ -84,7 +134,7 @@ function Footer() {
                 })}
               </div>
             )}
-            {links?.documentation && (
+            {footerData.links?.documentation && (
               <div>
                 <h5
                   css={`
@@ -94,7 +144,7 @@ function Footer() {
                 >
                   Documentation
                 </h5>
-                {links.documentation.map((link, i) => {
+                {footerData.links.documentation.map((link, i) => {
                   return (
                     <Link key={i} href={link.link} external>
                       {link.label}


### PR DESCRIPTION
Added a default data object for the footer in case there is no Garden connected, so `<Footer />` can be displayed on the Home page. This solves [#289](https://github.com/1Hive/gardens/issues/289) issue. 
![Screenshot from 2021-08-26 00-56-07](https://user-images.githubusercontent.com/78225502/130875007-846e9f86-8a96-4955-ae99-04fd730ef6b0.png)

*This also shows on the Profile route, should make an exception for it?*