### PR TITLE
UX: Close modal after success

### DIFF
--- a/src/components/Garden/ModalFlows/SignAgreementScreens/SignAgreementScreens.js
+++ b/src/components/Garden/ModalFlows/SignAgreementScreens/SignAgreementScreens.js
@@ -19,7 +19,7 @@ function SignAgreementScreens({ versionId }) {
     history.push(path)
   }, [history])
 
-  const renderOnCompleteActions = useCallback(() => {
+  const onCompleteActions = useMemo(() => {
     return (
       <Button
         label="Create proposal"
@@ -57,7 +57,7 @@ function SignAgreementScreens({ versionId }) {
       transactions={transactions}
       transactionTitle="Sign Covenant"
       screens={screens}
-      onCompleteActions={renderOnCompleteActions}
+      onCompleteActions={onCompleteActions}
     />
   )
 }

--- a/src/components/Garden/ModalFlows/StakeScreens/StakeScreens.js
+++ b/src/components/Garden/ModalFlows/StakeScreens/StakeScreens.js
@@ -23,7 +23,7 @@ function StakeScreens({ mode, stakeManagement, stakeActions }) {
     history.push(path)
   }, [history])
 
-  const renderOnCompleteActions = useCallback(() => {
+  const onCompleteActions = useMemo(() => {
     if (mode === 'deposit') {
       return (
         <Button
@@ -120,7 +120,7 @@ function StakeScreens({ mode, stakeManagement, stakeActions }) {
           : `Withdraw ${token.symbol}`
       }
       screens={screens}
-      onCompleteActions={renderOnCompleteActions}
+      onCompleteActions={onCompleteActions}
     />
   )
 }

--- a/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
@@ -25,7 +25,7 @@ function SupportProposalScreens({ proposal, mode }) {
     history.push(path)
   }, [history])
 
-  const renderOnCompleteActions = useCallback(() => {
+  const onCompleteActions = useMemo(() => {
     if (mode === 'support') {
       return (
         <div
@@ -132,7 +132,7 @@ function SupportProposalScreens({ proposal, mode }) {
         mode === 'support' ? 'Support this proposal' : 'Change support'
       }
       screens={screens}
-      onCompleteActions={renderOnCompleteActions}
+      onCompleteActions={onCompleteActions}
     />
   )
 }

--- a/src/components/Stepper/Stepper.js
+++ b/src/components/Stepper/Stepper.js
@@ -3,6 +3,12 @@ import { PropTypes } from 'prop-types'
 import { Transition, animated } from 'react-spring/renderprops'
 import { GU, noop, springs, useTheme } from '@1hive/1hive-ui'
 import Step from './Step/Step'
+
+import { useDisableAnimation } from '@hooks/useDisableAnimation'
+import { useMounted } from '@hooks/useMounted'
+import { useMultiModal } from '../MultiModal/MultiModalProvider'
+import useStepperLayout from './useStepperLayout'
+
 import {
   STEP_ERROR,
   STEP_PROMPTING,
@@ -11,9 +17,6 @@ import {
   STEP_WORKING,
 } from './stepper-statuses'
 import { TRANSACTION_SIGNING_DESC } from './stepper-descriptions'
-import { useDisableAnimation } from '@hooks/useDisableAnimation'
-import { useMounted } from '@hooks/useMounted'
-import useStepperLayout from './useStepperLayout'
 
 const AnimatedDiv = animated.div
 
@@ -45,6 +48,7 @@ function reduceSteps(steps, [action, stepIndex, value]) {
 function Stepper({ steps, onComplete, onCompleteActions }) {
   const theme = useTheme()
   const mounted = useMounted()
+  const { close } = useMultiModal()
   const [animationDisabled, enableAnimation] = useDisableAnimation()
   const [stepperStage, setStepperStage] = useState(0)
   const [stepState, updateStep] = useReducer(
@@ -159,6 +163,16 @@ function Stepper({ steps, onComplete, onCompleteActions }) {
     stepperStage === stepsCount &&
     stepState[stepperStage].status === STEP_SUCCESS
 
+  useEffect(() => {
+    let timeout
+    if (completed && !onCompleteActions) {
+      timeout = setTimeout(() => close(), 2000)
+    }
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [close, completed, onCompleteActions])
+
   return (
     <div
       css={`
@@ -244,7 +258,7 @@ function Stepper({ steps, onComplete, onCompleteActions }) {
             margin-top: ${5 * GU}px;
           `}
         >
-          {onCompleteActions()}
+          {onCompleteActions}
         </div>
       )}
     </div>
@@ -266,7 +280,7 @@ Stepper.propTypes = {
     })
   ).isRequired,
   onComplete: PropTypes.func,
-  onCompleteActions: PropTypes.func,
+  onCompleteActions: PropTypes.node,
 }
 
 Stepper.defaultProps = {


### PR DESCRIPTION
closes https://github.com/1Hive/gardens/issues/306

Closes modal stepper after all steps have completed.

- Time to pass between step completed and modal closes is set to 2 seconds
- This behavior is omitted if `onCompleteActions !== null`
