### PR TITLE
Sort proposals by newest after proposal created

### DIFF
--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -74,6 +74,10 @@ const Home = React.memo(function Home() {
     handleShowModal('unwrap')
   }, [handleShowModal])
 
+  const handleProposalCreated = useCallback(() => {
+    filters.ranking.onChange(1)
+  }, [filters])
+
   useEffect(() => {
     // Components that redirect to create a proposal will do so through "garden/${gardenId}/create" url
     if (account && history.location.pathname.includes('create')) {
@@ -195,7 +199,9 @@ const Home = React.memo(function Home() {
             onClose={handleHideModal}
             onClosed={() => setModalMode(null)}
           >
-            {modalMode === 'createProposal' && <CreateProposalScreens />}
+            {modalMode === 'createProposal' && (
+              <CreateProposalScreens onComplete={handleProposalCreated} />
+            )}
             {modalMode === 'wrap' && <WrapTokenScreens mode="wrap" />}
             {modalMode === 'unwrap' && <WrapTokenScreens mode="unwrap" />}
           </MultiModal>

--- a/src/components/Garden/ModalFlows/CreateProposalScreens/CreateProposalScreens.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/CreateProposalScreens.js
@@ -8,7 +8,7 @@ import { useWallet } from '@providers/Wallet'
 import useActions from '@hooks/useActions'
 import { useStakingState } from '@providers/Staking'
 
-function CreateProposalScreens() {
+function CreateProposalScreens({ onComplete }) {
   const [loading, setLoading] = useState(true)
   const [transactions, setTransactions] = useState([])
   const { account } = useWallet()
@@ -113,6 +113,7 @@ function CreateProposalScreens() {
       transactions={transactions}
       transactionTitle="Create proposal"
       screens={screens}
+      onComplete={onComplete}
     />
   )
 }

--- a/src/components/Garden/ModalFlows/ModalFlowBase.js
+++ b/src/components/Garden/ModalFlows/ModalFlowBase.js
@@ -22,6 +22,7 @@ function ModalFlowBase({
   screens,
   transactions,
   transactionTitle,
+  onComplete,
   onCompleteActions,
 }) {
   const { ethers } = useWallet()
@@ -97,6 +98,7 @@ function ModalFlowBase({
         content: (
           <Stepper
             steps={transactionSteps}
+            onComplete={onComplete}
             onCompleteActions={onCompleteActions}
           />
         ),
@@ -105,12 +107,13 @@ function ModalFlowBase({
 
     return allScreens
   }, [
-    transactions,
+    frontLoad,
+    loading,
     screens,
+    transactions,
     transactionSteps,
     transactionTitle,
-    loading,
-    frontLoad,
+    onComplete,
     onCompleteActions,
   ])
 


### PR DESCRIPTION
@0xmiel proposed to sort proposals by newest after a proposal is created so authors of proposals can immediately go and check the proposal without having to do any extra filtering by themselves.