### PR TITLE
Proposal Page: Add Proposal Context

### DIFF
--- a/src/components/Garden/ModalFlows/SettleProposalScreens/SettleProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SettleProposalScreens/SettleProposalScreens.js
@@ -1,34 +1,17 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import { addressesEqual } from '@1hive/1hive-ui'
 import ModalFlowBase from '../ModalFlowBase'
 import SettlementDetails from './SettlementDetails'
 import useActions from '@hooks/useActions'
 import { useWallet } from '@providers/Wallet'
 
-import { hexToUtf8 } from 'web3-utils'
-
 function SettleProposalScreens({ proposal }) {
-  const [loading, setLoading] = useState(true)
   const [transactions, setTransactions] = useState([])
-  const [challengeContext, setChallengeContext] = useState()
 
   const { account } = useWallet()
   const { agreementActions } = useActions()
 
   const isChallenger = addressesEqual(account, proposal.challenger)
-
-  useEffect(() => {
-    // we need to do this contract call here to get the challenge because in the agreement connector we don't have a challenge entity
-    // at some point for gardens we might want to have that done on the connector
-    async function getChallengeData() {
-      const challengeData = await agreementActions.getChallenge(
-        proposal.challengeId
-      )
-      setChallengeContext(hexToUtf8(challengeData.context))
-      setLoading(false)
-    }
-    getChallengeData()
-  }, [agreementActions, proposal])
 
   const getTransactions = useCallback(
     async onComplete => {
@@ -49,7 +32,6 @@ function SettleProposalScreens({ proposal }) {
         title: isChallenger ? 'Claim collateral' : 'Accept settlement offer',
         content: (
           <SettlementDetails
-            challengeContext={challengeContext}
             getTransactions={getTransactions}
             isChallenger={isChallenger}
             proposal={proposal}
@@ -57,13 +39,12 @@ function SettleProposalScreens({ proposal }) {
         ),
       },
     ],
-    [challengeContext, getTransactions, isChallenger, proposal]
+    [getTransactions, isChallenger, proposal]
   )
 
   return (
     <ModalFlowBase
       screens={screens}
-      loading={loading}
       transactions={transactions}
       transactionTitle={isChallenger ? 'Claim collateral' : 'Accept settlement'}
     />

--- a/src/components/Garden/ModalFlows/SettleProposalScreens/SettlementDetails.js
+++ b/src/components/Garden/ModalFlows/SettleProposalScreens/SettlementDetails.js
@@ -4,16 +4,13 @@ import InfoField from '../../InfoField'
 import ModalButton from '../ModalButton'
 import { formatTokenAmount } from '@utils/token-utils'
 import { useMultiModal } from '@components/MultiModal/MultiModalProvider'
+import useChallenge from '@hooks/useChallenge'
 
-function SettlementDetails({
-  challengeContext,
-  getTransactions,
-  isChallenger,
-  proposal,
-}) {
+function SettlementDetails({ getTransactions, isChallenger, proposal }) {
   const { id, challenger, collateralRequirement, settlementOffer } = proposal
   const { layoutName } = useLayout()
   const { next } = useMultiModal()
+  const { challenge, loading } = useChallenge(proposal)
 
   const handleOnContinue = useCallback(() => {
     getTransactions(() => {
@@ -73,7 +70,7 @@ function SettlementDetails({
           margin-top: ${3 * GU}px;
         `}
       >
-        {challengeContext}
+        {!loading && challenge.context}
       </InfoField>
       <ModalButton mode="strong" loading={false} onClick={handleOnContinue}>
         {isChallenger ? 'Claim deposit' : 'Accept settlement'}

--- a/src/components/Garden/ProposalDetail/ProposalDetail.js
+++ b/src/components/Garden/ProposalDetail/ProposalDetail.js
@@ -311,21 +311,20 @@ function ProposalDetail({
                   />
                 </section>
               </Box>
-              {(statusData.challenged || statusData.settled) &&
-                connectedAccount && (
-                  <Box
-                    padding={2.4 * GU}
-                    css={`
-                      background: ${background};
-                      border-color: ${borderColor};
-                    `}
-                  >
-                    <ArgumentBox
-                      proposal={proposal}
-                      connectedAccount={connectedAccount}
-                    />
-                  </Box>
-                )}
+              {(statusData.challenged || statusData.settled) && (
+                <Box
+                  padding={2.4 * GU}
+                  css={`
+                    background: ${background};
+                    border-color: ${borderColor};
+                  `}
+                >
+                  <ArgumentBox
+                    proposal={proposal}
+                    connectedAccount={connectedAccount}
+                  />
+                </Box>
+              )}
             </>
           }
           secondary={

--- a/src/components/Garden/ProposalDetail/ProposalDetail.js
+++ b/src/components/Garden/ProposalDetail/ProposalDetail.js
@@ -4,10 +4,15 @@ import {
   BackButton,
   Box,
   Button,
+  EthIdenticon,
   GU,
   Help,
+  IconDown,
+  IconUp,
   Link,
+  shortenAddress,
   Split,
+  Tag,
   textStyle,
   useLayout,
   useTheme,
@@ -35,6 +40,7 @@ import SupportProposalScreens from '../ModalFlows/SupportProposal/SupportProposa
 
 // Hooks
 import { useWallet } from '@providers/Wallet'
+import useChallenge from '@hooks/useChallenge'
 
 // utils
 import BigNumber from '@lib/bigNumber'
@@ -45,6 +51,9 @@ import {
 } from '@utils/web3-utils'
 import { ProposalTypes } from '@/types'
 import { ZERO_ADDR } from '@/constants'
+
+// assets
+import warningIcon from '../Agreement/assets/warning.svg'
 
 const CANCEL_ROLE_HASH = soliditySha3('CANCEL_PROPOSAL_ROLE')
 
@@ -143,161 +152,181 @@ function ProposalDetail({
       >
         <Split
           primary={
-            <Box
-              css={`
-                background: ${background};
-                border-color: ${borderColor};
-              `}
-            >
-              <section
+            <>
+              <Box
                 css={`
-                  display: grid;
-                  grid-template-rows: auto;
-                  grid-row-gap: ${7 * GU}px;
+                  background: ${background};
+                  border-color: ${borderColor};
                 `}
               >
-                <div>
-                  <ProposalHeader proposal={proposal} />
-                  <h1
-                    css={`
-                      ${textStyle('title2')};
-                    `}
-                  >
-                    {name}
-                  </h1>
-                  <div
-                    css={`
-                      margin-top: ${2 * GU}px;
-                      grid-column: span 2;
-                      min-width: ${40 * GU}px;
-                      color: ${theme.contentSecondary};
-                    `}
-                  >
-                    {fundingProposal ? (
-                      <span>
-                        This proposal is requesting{' '}
-                        <strong>
-                          {formatTokenAmount(
-                            requestedAmountConverted,
-                            requestToken.decimals
-                          )}
-                        </strong>{' '}
-                        {requestToken.symbol} out of{' '}
-                        <strong>
-                          {formatTokenAmount(commonPool, requestToken.decimals)}
-                        </strong>{' '}
-                        {requestToken.symbol} currently in the common pool.
-                      </span>
-                    ) : (
-                      <span>
-                        This suggestion is for signaling purposes and is not
-                        requesting any {requestToken.symbol}
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div
+                <section
                   css={`
                     display: grid;
-                    grid-template-columns: ${layoutName !== 'small'
-                      ? 'auto auto auto'
-                      : 'auto'};
-                    grid-gap: ${layoutName !== 'small' ? 5 * GU : 2.5 * GU}px;
+                    grid-template-rows: auto;
+                    grid-row-gap: ${7 * GU}px;
                   `}
                 >
-                  <DataField
-                    label="Forum"
-                    value={
-                      link ? (
-                        <Link href={link} external>
-                          Read the full proposal
-                        </Link>
-                      ) : (
-                        <span
-                          css={`
-                            ${textStyle('body2')};
-                          `}
-                        >
-                          No link provided
+                  <div>
+                    <ProposalHeader proposal={proposal} />
+                    <h1
+                      css={`
+                        ${textStyle('title2')};
+                      `}
+                    >
+                      {name}
+                    </h1>
+                    <div
+                      css={`
+                        margin-top: ${2 * GU}px;
+                        grid-column: span 2;
+                        min-width: ${40 * GU}px;
+                        color: ${theme.contentSecondary};
+                      `}
+                    >
+                      {fundingProposal ? (
+                        <span>
+                          This proposal is requesting{' '}
+                          <strong>
+                            {formatTokenAmount(
+                              requestedAmountConverted,
+                              requestToken.decimals
+                            )}
+                          </strong>{' '}
+                          {requestToken.symbol} out of{' '}
+                          <strong>
+                            {formatTokenAmount(
+                              commonPool,
+                              requestToken.decimals
+                            )}
+                          </strong>{' '}
+                          {requestToken.symbol} currently in the common pool.
                         </span>
-                      )
-                    }
-                    css="grid-column-start: span 2;"
-                  />
-                  <DataField
-                    label="Status"
-                    value={<ProposalStatus proposal={proposal} />}
-                  />
-                  {fundingProposal && (
-                    <Amount
-                      requestedAmount={requestedAmount}
-                      requestedAmountConverted={requestedAmountConverted}
-                      requestToken={requestToken}
-                      stable={stable}
-                      stableToken={stableToken}
-                    />
-                  )}
-
-                  {fundingProposal && (
+                      ) : (
+                        <span>
+                          This suggestion is for signaling purposes and is not
+                          requesting any {requestToken.symbol}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div
+                    css={`
+                      display: grid;
+                      grid-template-columns: ${layoutName !== 'small'
+                        ? 'auto auto auto'
+                        : 'auto'};
+                      grid-gap: ${layoutName !== 'small' ? 5 * GU : 2.5 * GU}px;
+                    `}
+                  >
                     <DataField
-                      label="Beneficiary"
+                      label="Forum"
+                      value={
+                        link ? (
+                          <Link href={link} external>
+                            Read the full proposal
+                          </Link>
+                        ) : (
+                          <span
+                            css={`
+                              ${textStyle('body2')};
+                            `}
+                          >
+                            No link provided
+                          </span>
+                        )
+                      }
+                      css="grid-column-start: span 2;"
+                    />
+                    <DataField
+                      label="Status"
+                      value={<ProposalStatus proposal={proposal} />}
+                    />
+                    {fundingProposal && (
+                      <Amount
+                        requestedAmount={requestedAmount}
+                        requestedAmountConverted={requestedAmountConverted}
+                        requestToken={requestToken}
+                        stable={stable}
+                        stableToken={stableToken}
+                      />
+                    )}
+
+                    {fundingProposal && (
+                      <DataField
+                        label="Beneficiary"
+                        value={
+                          <IdentityBadge
+                            connectedAccount={addressesEqual(
+                              beneficiary,
+                              connectedAccount
+                            )}
+                            entity={beneficiary}
+                          />
+                        }
+                      />
+                    )}
+                    <DataField
+                      label="Created By"
                       value={
                         <IdentityBadge
                           connectedAccount={addressesEqual(
-                            beneficiary,
+                            creator,
                             connectedAccount
                           )}
-                          entity={beneficiary}
+                          entity={creator}
+                        />
+                      }
+                    />
+                    {proposal.number !== '1' && (
+                      <>
+                        <DataField
+                          label="Deposit Amount"
+                          value={<ActionCollateral proposal={proposal} />}
+                        />
+                        {proposal.pausedAt > 0 && (
+                          <DisputeFees proposal={proposal} />
+                        )}
+                      </>
+                    )}
+                  </div>
+                  {(statusData.open ||
+                    statusData.challenged ||
+                    statusData.disputed) && (
+                    <DataField
+                      label="Progress"
+                      value={
+                        <ConvictionBar
+                          proposal={proposal}
+                          withThreshold={!!requestToken}
                         />
                       }
                     />
                   )}
-                  <DataField
-                    label="Created By"
-                    value={
-                      <IdentityBadge
-                        connectedAccount={addressesEqual(
-                          creator,
-                          connectedAccount
-                        )}
-                        entity={creator}
-                      />
-                    }
+                  <DisputableInfo proposal={proposal} />
+                  <ProposalActions
+                    proposal={proposal}
+                    onChangeSupport={() => handleShowModal('update')}
+                    onExecuteProposal={() => handleShowModal('execute')}
+                    onRequestSupportProposal={() => handleShowModal('support')}
                   />
-                  {proposal.number !== '1' && (
-                    <>
-                      <DataField
-                        label="Deposit Amount"
-                        value={<ActionCollateral proposal={proposal} />}
-                      />
-                      {proposal.pausedAt > 0 && (
-                        <DisputeFees proposal={proposal} />
-                      )}
-                    </>
-                  )}
-                </div>
-                {(statusData.open ||
-                  statusData.challenged ||
-                  statusData.disputed) && (
-                  <DataField
-                    label="Progress"
-                    value={
-                      <ConvictionBar
-                        proposal={proposal}
-                        withThreshold={!!requestToken}
-                      />
-                    }
-                  />
+                </section>
+              </Box>
+              {(statusData.challenged || statusData.settled) &&
+                connectedAccount && (
+                  <Box
+                    padding={2.4 * GU}
+                    css={`
+                      background: ${background};
+                      border-color: ${borderColor};
+                    `}
+                  >
+                    <ArgumentBox
+                      proposal={proposal}
+                      connectedAccount={connectedAccount}
+                    />
+                  </Box>
                 )}
-                <DisputableInfo proposal={proposal} />
-                <ProposalActions
-                  proposal={proposal}
-                  onChangeSupport={() => handleShowModal('update')}
-                  onExecuteProposal={() => handleShowModal('execute')}
-                  onRequestSupportProposal={() => handleShowModal('support')}
-                />
-              </section>
-            </Box>
+            </>
           }
           secondary={
             <div>
@@ -385,6 +414,131 @@ function ProposalDetail({
         )}
       </MultiModal>
     </div>
+  )
+}
+
+function ArgumentBox({ proposal, connectedAccount }) {
+  const theme = useTheme()
+
+  const { challenge } = useChallenge(proposal)
+  const [showArgument, setShowArgument] = useState(false)
+
+  return (
+    <>
+      <div
+        css={`
+          display: flex;
+          justify-content: space-between;
+          ${textStyle('body1')};
+          color: ${theme.warning};
+        `}
+      >
+        <div
+          css={`
+            display: grid;
+            grid-template-columns: ${5 * GU}px ${35 * GU}px;
+            align-items: center;
+          `}
+        >
+          <img src={warningIcon} width={30} height={30} />
+          <h1>
+            {connectedAccount === proposal.creator ? 'Your' : 'This'} proposal
+            has been challenged
+          </h1>
+        </div>
+        <div
+          onClick={() => setShowArgument(!showArgument)}
+          css={`
+            display: flex;
+            align-items: center;
+            :hover {
+              cursor: pointer;
+              text-decoration: underline;
+            }
+          `}
+        >
+          <h1
+            css={`
+              width: ${18 * GU}px;
+            `}
+          >
+            {showArgument ? 'Hide' : 'Show'} arguments
+          </h1>
+          {showArgument ? <IconUp /> : <IconDown />}
+        </div>
+      </div>
+      {showArgument && (
+        <div
+          css={`
+            display: flex;
+            justify-content: flex-start;
+            margin: ${4.5 * GU}px ${4.5 * GU}px 0 0;
+          `}
+        >
+          <div
+            css={`
+              width: ${5 * GU}px;
+              margin-right: ${5 * GU}px;
+            `}
+          >
+            {challenge.challenger.image ? (
+              <img
+                src={challenge.challenger.image}
+                height={43}
+                width={43}
+                css={`
+                  border-radius: 50%;
+                `}
+              />
+            ) : (
+              <EthIdenticon
+                address={challenge.challenger.address}
+                radius={50}
+                scale={1.8}
+              />
+            )}
+          </div>
+          <div
+            css={`
+              flex-direction: column;
+            `}
+          >
+            <div
+              css={`
+                display: flex;
+                justify-content: flex-start;
+                width: ${30 * GU}px;
+              `}
+            >
+              <h2
+                css={`
+                  font-weight: 600;
+                  margin-right: ${1 * GU}px;
+                `}
+              >
+                {challenge.challenger.name
+                  ? challenge.challenger.name
+                  : shortenAddress(challenge.challenger.address)}
+              </h2>
+              <Tag
+                background={theme.warningSurface.toString()}
+                color={theme.warningSurfaceContent.toString()}
+              >
+                challenger
+              </Tag>
+            </div>
+            <div
+              css={`
+                margin-top: ${1.5 * GU}px;
+                color: ${theme.contentSecondary};
+              `}
+            >
+              {challenge.context}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/src/hooks/useActions.js
+++ b/src/hooks/useActions.js
@@ -15,7 +15,6 @@ import { VOTE_YEA } from '@/constants'
 import { encodeFunctionData } from '@utils/web3-utils'
 import BigNumber from '@lib/bigNumber'
 import tokenAbi from '@abis/minimeToken.json'
-import agreementAbi from '@abis/agreement.json'
 
 const GAS_LIMIT = 450000
 const RESOLVE_GAS_LIMIT = 700000
@@ -42,8 +41,6 @@ export default function useActions() {
     installedApps,
     env('HOOKED_TOKEN_MANAGER_APP_NAME')
   )
-
-  const agreementContract = useContract(agreementApp?.address, agreementAbi)
 
   // Conviction voting actions
   const newProposal = useCallback(
@@ -336,19 +333,6 @@ export default function useActions() {
     [account, agreementApp, mounted]
   )
 
-  const getChallenge = useCallback(
-    async challengeId => {
-      if (!agreementContract) {
-        return
-      }
-
-      const challengeData = await agreementContract.getChallenge(challengeId)
-
-      return challengeData
-    },
-    [agreementContract]
-  )
-
   // Hoked token manager actions
   const approveWrappableTokenAmount = useCallback(
     (amount, onDone = noop) => {
@@ -420,7 +404,6 @@ export default function useActions() {
       challengeAction,
       disputeAction,
       getAllowance: getAgreementTokenAllowance,
-      getChallenge,
       resolveAction,
       settleAction,
       signAgreement,

--- a/src/hooks/useChallenge.js
+++ b/src/hooks/useChallenge.js
@@ -1,10 +1,20 @@
 import { useEffect, useState } from 'react'
-import useActions from '@hooks/useActions'
-import { hexToUtf8 } from '@utils/web3-utils'
+
+import { useContractReadOnly } from './useContract'
+import { useMounted } from './useMounted'
+import { useGardenState } from '@providers/GardenState'
 import { getProfileForAccount } from '@lib/profile'
+import { hexToUtf8 } from '@utils/web3-utils'
+import agreementAbi from '../abi/agreement.json'
 
 export default function useChallenge(proposal) {
-  const { agreementActions } = useActions()
+  const { connectedAgreementApp } = useGardenState()
+  const mounted = useMounted()
+
+  const agreementContract = useContractReadOnly(
+    connectedAgreementApp.address,
+    agreementAbi
+  )
 
   const [challenge, setChallenge] = useState()
   const [loading, setLoading] = useState(true)
@@ -14,22 +24,26 @@ export default function useChallenge(proposal) {
       return
     }
     async function getChallengeData() {
-      const challengeData = await agreementActions.getChallenge(
+      const challengeData = await agreementContract.getChallenge(
         proposal.challengeId
       )
       const challengerProfile = await getProfileForAccount(
         challengeData.challenger
       )
-
-      setChallenge({
-        context: hexToUtf8(challengeData.context),
-        challenger: { address: challengeData.challenger, ...challengerProfile },
-      })
+      if (mounted()) {
+        setChallenge({
+          context: hexToUtf8(challengeData.context),
+          challenger: {
+            address: challengeData.challenger,
+            ...challengerProfile,
+          },
+        })
+      }
       setLoading(false)
     }
 
     getChallengeData()
-  }, [proposal.challengeId])
+  }, [proposal.challengeId, mounted, agreementContract])
 
   return { challenge, loading }
 }

--- a/src/hooks/useChallenge.js
+++ b/src/hooks/useChallenge.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import useActions from '@hooks/useActions'
+import { hexToUtf8 } from '@utils/web3-utils'
+import { getProfileForAccount } from '@lib/profile'
+
+export default function useChallenge(proposal) {
+  const { agreementActions } = useActions()
+
+  const [challenge, setChallenge] = useState()
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!proposal) {
+      return
+    }
+    async function getChallengeData() {
+      const challengeData = await agreementActions.getChallenge(
+        proposal.challengeId
+      )
+      const challengerProfile = await getProfileForAccount(
+        challengeData.challenger
+      )
+
+      setChallenge({
+        context: hexToUtf8(challengeData.context),
+        challenger: { address: challengeData.challenger, ...challengerProfile },
+      })
+      setLoading(false)
+    }
+
+    getChallengeData()
+  }, [proposal.challengeId])
+
+  return { challenge, loading }
+}

--- a/src/hooks/useChallenge.js
+++ b/src/hooks/useChallenge.js
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
 
 import { useContractReadOnly } from './useContract'
-import { useMounted } from './useMounted'
 import { useGardenState } from '@providers/GardenState'
+import { useMounted } from './useMounted'
+
 import { getProfileForAccount } from '@lib/profile'
 import { hexToUtf8 } from '@utils/web3-utils'
+
 import agreementAbi from '../abi/agreement.json'
 
 export default function useChallenge(proposal) {
@@ -43,7 +45,7 @@ export default function useChallenge(proposal) {
     }
 
     getChallengeData()
-  }, [proposal.challengeId, mounted, agreementContract])
+  }, [agreementContract, mounted, proposal])
 
   return { challenge, loading }
 }

--- a/src/utils/web3-utils.js
+++ b/src/utils/web3-utils.js
@@ -109,4 +109,10 @@ export function addressesEqualNoSum(first, second) {
 }
 
 // Re-export some web3-utils functions
-export { isAddress, toChecksumAddress, toUtf8, soliditySha3 } from 'web3-utils'
+export {
+  hexToUtf8,
+  isAddress,
+  toChecksumAddress,
+  toUtf8,
+  soliditySha3,
+} from 'web3-utils'


### PR DESCRIPTION
It displays Proposal context and Challenger data on the Proposal Page, so you don't have to click 'Accept settlement' to read it.

This is the [figma](https://www.figma.com/file/IGMjM4UyW2yp9ImEUsHduG/%E2%9C%A8Improvements-based-on-UX-research?node-id=0%3A1) used.

This solves [issue #268](https://github.com/1Hive/gardens/issues/268).

