### PR TITLE
Add Gardens filters and pagination

### DIFF
--- a/src/components/GardensFilters.js
+++ b/src/components/GardensFilters.js
@@ -1,0 +1,68 @@
+import styled from 'styled-components'
+import { DropDown, GU, SearchInput, useLayout } from '@1hive/1hive-ui'
+import React from 'react'
+
+const GardensFilters = ({
+  itemsNetwork,
+  itemsSorting,
+  nameFilter,
+  networkFilter,
+  sortingFilter,
+  onNameFilterChange,
+  onNetworkFilterChange,
+  onSortingFilterChange,
+}) => {
+  const { layoutName } = useLayout()
+
+  return (
+    <div
+      css={`
+        display: flex;
+        justify-content: center;
+        width: ${layoutName === 'max' ? '65%' : 'auto'};
+        gap: ${1 * GU}px;
+        flex-wrap: wrap;
+      `}
+    >
+      <FilterItem>
+        <DropDown
+          header="Network"
+          items={itemsNetwork}
+          onChange={onNetworkFilterChange}
+          selected={networkFilter}
+          disabled
+          wide
+        />
+      </FilterItem>
+      <FilterItem>
+        <DropDown
+          header="Sort by"
+          items={itemsSorting}
+          onChange={onSortingFilterChange}
+          selected={sortingFilter}
+          wide
+        />
+      </FilterItem>
+      {layoutName !== 'max' && <Break />}
+      <FilterItem grow={2}>
+        <SearchInput
+          value={nameFilter}
+          onChange={onNameFilterChange}
+          placeholder="Search by Garden name"
+          wide
+        />
+      </FilterItem>
+    </div>
+  )
+}
+
+const FilterItem = styled.div`
+  flex: ${({ grow }) => grow ?? 1};
+`
+
+const Break = styled.div`
+  flex-basis: 100%;
+  height: 0;
+`
+
+export default GardensFilters

--- a/src/components/GardensList.js
+++ b/src/components/GardensList.js
@@ -1,28 +1,69 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
-import { GU, shortenAddress, textStyle, useTheme } from '@1hive/1hive-ui'
-
+import {
+  GU,
+  Pagination,
+  shortenAddress,
+  textStyle,
+  useTheme,
+} from '@1hive/1hive-ui'
 import { useGardens } from '@providers/Gardens'
-
 import defaultGardenLogo from '@assets/defaultGardenLogo.png'
 import defaultTokenLogo from '@assets/defaultTokenLogo.svg'
+import Loader from './Loader'
+
+const GARDENS_PER_PAGE = 8
+
+const computeCurrentGardens = (gardens, currentPage) => {
+  const currentGardens = gardens.slice(
+    currentPage * GARDENS_PER_PAGE,
+    GARDENS_PER_PAGE * (currentPage + 1)
+  )
+
+  return currentGardens
+}
 
 function GardensList() {
-  // TODO :  add loading component
-  const { gardens } = useGardens()
+  const { gardens, loading } = useGardens()
+  const [selectedPage, setSelectedPage] = useState(0)
+  const pages = Math.ceil(gardens.length / GARDENS_PER_PAGE)
+  const currentGardens = useMemo(
+    () => computeCurrentGardens(gardens, selectedPage),
+    [gardens, selectedPage]
+  )
+
+  const handlePageChange = useCallback(page => {
+    setSelectedPage(page)
+  }, [])
 
   return (
-    <div
-      css={`
-        padding: ${3 * GU}px;
-        display: grid;
-        grid-gap: ${2 * GU}px;
-        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-      `}
-    >
-      {gardens.map(garden => (
-        <GardenCard key={garden.id} garden={garden} />
-      ))}
+    <div>
+      {!loading ? (
+        <div>
+          <div
+            css={`
+              padding: ${3 * GU}px;
+              display: grid;
+              grid-gap: ${4 * GU}px;
+              grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+              grid-template-rows: repeat(auto-fill, minmax(280px, 1fr));
+            `}
+          >
+            {currentGardens.map(garden => (
+              <GardenCard key={garden.id} garden={garden} />
+            ))}
+          </div>
+          {pages > 1 && (
+            <Pagination
+              pages={pages}
+              selected={selectedPage}
+              onChange={handlePageChange}
+            />
+          )}
+        </div>
+      ) : (
+        <Loader />
+      )}
     </div>
   )
 }

--- a/src/components/GardensList.js
+++ b/src/components/GardensList.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
 import {
   GU,
@@ -7,10 +7,9 @@ import {
   textStyle,
   useTheme,
 } from '@1hive/1hive-ui'
-import { useGardens } from '@providers/Gardens'
 import defaultGardenLogo from '@assets/defaultGardenLogo.png'
 import defaultTokenLogo from '@assets/defaultTokenLogo.svg'
-import Loader from './Loader'
+import EmptyResults from './Garden/Feed/EmptyResults'
 
 const GARDENS_PER_PAGE = 8
 
@@ -23,8 +22,7 @@ const computeCurrentGardens = (gardens, currentPage) => {
   return currentGardens
 }
 
-function GardensList() {
-  const { gardens, loading } = useGardens()
+function GardensList({ gardens }) {
   const [selectedPage, setSelectedPage] = useState(0)
   const pages = Math.ceil(gardens.length / GARDENS_PER_PAGE)
   const currentGardens = useMemo(
@@ -36,17 +34,23 @@ function GardensList() {
     setSelectedPage(page)
   }, [])
 
+  useEffect(() => {
+    if (gardens.length) {
+      setSelectedPage(0)
+    }
+  }, [gardens])
+
   return (
     <div>
-      {!loading ? (
+      {currentGardens.length ? (
         <div>
           <div
             css={`
-              padding: ${3 * GU}px;
               display: grid;
               grid-gap: ${4 * GU}px;
-              grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-              grid-template-rows: repeat(auto-fill, minmax(280px, 1fr));
+              grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+              grid-template-rows: repeat(auto-fill, minmax(300px, 1fr));
+              margin-bottom: ${2 * GU}px;
             `}
           >
             {currentGardens.map(garden => (
@@ -62,7 +66,7 @@ function GardensList() {
           )}
         </div>
       ) : (
-        <Loader />
+        <EmptyResults title="No gardens found" />
       )}
     </div>
   )

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,14 +1,18 @@
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
-import { useToast } from '@1hive/1hive-ui'
-
-import GardensList from './GardensList'
-import Onboarding from './Onboarding'
-import LandingBanner from './LandingBanner'
+import { GU, useToast } from '@1hive/1hive-ui'
 import { useNodeHeight } from '@hooks/useNodeHeight'
+import { useGardens } from '@/providers/Gardens'
+
+import GardensFilters from './GardensFilters'
+import GardensList from './GardensList'
+import LandingBanner from './LandingBanner'
+import Onboarding from './Onboarding'
+import Loader from './Loader'
 
 function Home() {
   const [height, ref] = useNodeHeight()
+  const { externalFilters, internalFilters, gardens, loading } = useGardens()
   const [onboardingVisible, setOnboardingVisible] = useState(false)
   const toast = useToast()
 
@@ -24,8 +28,29 @@ function Home() {
   return (
     <div>
       <LandingBanner ref={ref} onCreateGarden={handleOnboardingOpen} />
-      <DynamicDiv marginTop={height}>
-        <GardensList />
+      <DynamicDiv
+        marginTop={height + 3 * GU}
+        css={`
+          padding: 0 ${2 * GU}px;
+        `}
+      >
+        <GardensFilters
+          itemsNetwork={externalFilters.network.items}
+          itemsSorting={externalFilters.sorting.items}
+          nameFilter={internalFilters.name.filter}
+          networkFilter={externalFilters.network.filter}
+          sortingFilter={externalFilters.sorting.filter}
+          onNameFilterChange={internalFilters.name.onChange}
+          onNetworkFilterChange={externalFilters.network.onChange}
+          onSortingFilterChange={externalFilters.sorting.onChange}
+        />
+        <div
+          css={`
+            margin: ${5 * GU}px 0;
+          `}
+        >
+          {!loading ? <GardensList gardens={gardens} /> : <Loader />}
+        </div>
       </DynamicDiv>
       <Onboarding onClose={handleOnboardingClose} visible={onboardingVisible} />
     </div>

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce(value, delay) {
+  // State and setters for debounced value
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(
+    () => {
+      // Update debounced value after delay
+      const handler = setTimeout(() => {
+        setDebouncedValue(value)
+      }, delay)
+      // Cancel the timeout if value changes (also on delay change or unmount)
+      // This is how we prevent debounced value from updating if value is changed ...
+      // .. within the delay period. Timeout gets cleared and restarted.
+      return () => {
+        clearTimeout(handler)
+      }
+    },
+    [value, delay] // Only re-call effect if value or delay changes
+  )
+
+  return debouncedValue
+}

--- a/src/hooks/useGardenFilters.js
+++ b/src/hooks/useGardenFilters.js
@@ -1,0 +1,82 @@
+import { getNetwork } from '@/networks'
+import {
+  filterArgsMapping,
+  FILTER_KEY_NAME,
+  FILTER_KEY_NETWORK,
+  FILTER_KEY_SORTING,
+  NETWORK_FILTER_RINKEBY,
+  NETWORK_FILTER_XDAI,
+  NETWORK_ITEMS,
+  SORTING_FILTER_LIQUIDITY,
+  SORTING_ITEMS,
+} from '@/utils/garden-filters-utils'
+import { useCallback, useMemo, useState } from 'react'
+
+const filtersCache = new Map([])
+
+export default function useGardenFilters() {
+  // Local filters
+  const [nameFilter, setNameFilter] = useState(
+    filtersCache.get(FILTER_KEY_NAME) || ''
+  )
+  // Subgraph query filters
+  const [networkFilter, setNetworkFilter] = useState(
+    filtersCache.get(FILTER_KEY_NETWORK) || getNetwork().chainId === 100
+      ? NETWORK_FILTER_XDAI
+      : NETWORK_FILTER_RINKEBY
+  )
+  const [sortingFilter, setSortingFilter] = useState(
+    filtersCache.get(FILTER_KEY_SORTING) || SORTING_FILTER_LIQUIDITY
+  )
+
+  const handleNameFilterChange = useCallback(newName => {
+    setNameFilter(newName)
+    filtersCache.set(FILTER_KEY_NAME, newName)
+  }, [])
+
+  const handleNetworkFilterChange = useCallback(newNetwork => {
+    setNetworkFilter(newNetwork)
+    filtersCache.set(FILTER_KEY_NETWORK, newNetwork)
+  }, [])
+
+  const handleSortingFilterChange = useCallback(index => {
+    setSortingFilter(index)
+    filtersCache.set(FILTER_KEY_SORTING, index)
+  }, [])
+
+  const queryFilters = useMemo(
+    () => ({
+      network: {
+        items: NETWORK_ITEMS,
+        filter: networkFilter,
+        onChange: handleNetworkFilterChange,
+        queryArgs: getQueryArgsByFilter('network', networkFilter),
+      },
+      sorting: {
+        items: SORTING_ITEMS,
+        filter: sortingFilter,
+        onChange: handleSortingFilterChange,
+        queryArgs: getQueryArgsByFilter('sorting', sortingFilter),
+      },
+    }),
+    [
+      networkFilter,
+      sortingFilter,
+      handleNetworkFilterChange,
+      handleSortingFilterChange,
+    ]
+  )
+  const filters = {
+    name: {
+      filter: nameFilter,
+      onChange: handleNameFilterChange,
+    },
+  }
+
+  return [queryFilters, filters]
+}
+
+function getQueryArgsByFilter(key, filter) {
+  const { queryKey } = filterArgsMapping[key]
+  return { [queryKey]: filterArgsMapping[key][filter] }
+}

--- a/src/utils/garden-filters-utils.js
+++ b/src/utils/garden-filters-utils.js
@@ -1,0 +1,37 @@
+export const NETWORK_FILTER_RINKEBY = 0
+export const NETWORK_FILTER_XDAI = 1
+export const SORTING_FILTER_LIQUIDITY = 0
+export const SORTING_FILTER_MEMBERS = 1
+export const SORTING_FILTER_PROPOSALS_COUNTER = 2
+
+export const FILTER_KEY_SORTING = 'sorting'
+export const FILTER_KEY_NETWORK = 'network'
+export const FILTER_KEY_NAME = 'name'
+
+export const SORTING_ITEMS = [
+  'More Liquidity',
+  'More Members',
+  'More Proposals',
+]
+export const NETWORK_ITEMS = ['Rinkeby', 'xDai']
+
+export const filterArgsMapping = {
+  name: {
+    queryKey: '',
+  },
+  network: {
+    queryKey: 'network',
+    [NETWORK_FILTER_XDAI]: 100,
+    [NETWORK_FILTER_RINKEBY]: 4,
+  },
+  sorting: {
+    queryKey: 'orderBy',
+    [SORTING_FILTER_LIQUIDITY]: 'honeyLiquidity',
+    [SORTING_FILTER_MEMBERS]: 'supporterCount',
+    [SORTING_FILTER_PROPOSALS_COUNTER]: 'proposalCount',
+  },
+}
+
+export const testNameFilter = (filterName, garden) => {
+  return garden.name && garden.name.includes(filterName)
+}


### PR DESCRIPTION
This PR adds pagination and filters to the gardens home page according to the figma designs. It solves both issue [#279](https://github.com/1Hive/gardens/issues/279) and [#379](https://github.com/1Hive/gardens/issues/319).

The pagination is being done locally but it may be necessary to do it on-demand as more gardens are created.

I added the network filter and its component but didn't implement the logic behind it as it involves a lot of work that should be done on a separate PR.

![image](https://user-images.githubusercontent.com/33203511/133631148-86b0a04c-764f-44a5-8052-0ef89bfa1d04.png)
