### PR TITLE
Proposal footer: Needed tokens fix

### DIFF
--- a/src/components/Garden/Feed/ProposalFooter.js
+++ b/src/components/Garden/Feed/ProposalFooter.js
@@ -69,7 +69,7 @@ function ProposalFooter({ proposal }) {
       <div>
         {supportersCount} Supporter{supportersCount === 1 ? '' : 's'}
       </div>
-      {proposal.type === ProposalTypes.Proposal && (
+      {proposal.type === ProposalTypes.Proposal && proposal.neededTokens > 0 && (
         <div>
           {stakeToken.symbol} needed to pass: {formattedNeededTokens}
         </div>


### PR DESCRIPTION
Only display needed tokens when value is `> 0`