### PR TITLE
Remove useActions from many screens

### DIFF
--- a/src/components/Garden/Agreement/Agreement.js
+++ b/src/components/Garden/Agreement/Agreement.js
@@ -13,12 +13,16 @@ import MultiModal from '@components/MultiModal/MultiModal'
 import SignAgreementScreens from '../ModalFlows/SignAgreementScreens/SignAgreementScreens'
 import { useAgreement } from '@hooks/useAgreement'
 import { useWallet } from '@providers/Wallet'
+import useGardenLogic from '@/logic/garden-logic'
 
 import warningSvg from './assets/warning.svg'
 
 function Agreement() {
   const [agreement, loading] = useAgreement()
   const [signModalVisible, setSignModalVisible] = useState(false)
+  const {
+    actions,
+  } = useGardenLogic()
 
   const signed = agreement.signedLatest
 
@@ -46,7 +50,7 @@ function Agreement() {
         />
       </LayoutLimiter>
       <MultiModal visible={signModalVisible} onClose={handleHideModal}>
-        <SignAgreementScreens versionId={agreement.versionId} />
+        <SignAgreementScreens versionId={agreement.versionId} actions={actions} />
       </MultiModal>
     </LayoutGutter>
   )

--- a/src/components/Garden/Agreement/Agreement.js
+++ b/src/components/Garden/Agreement/Agreement.js
@@ -20,9 +20,7 @@ import warningSvg from './assets/warning.svg'
 function Agreement() {
   const [agreement, loading] = useAgreement()
   const [signModalVisible, setSignModalVisible] = useState(false)
-  const {
-    actions,
-  } = useGardenLogic()
+  const { actions } = useGardenLogic()
 
   const signed = agreement.signedLatest
 
@@ -50,7 +48,10 @@ function Agreement() {
         />
       </LayoutLimiter>
       <MultiModal visible={signModalVisible} onClose={handleHideModal}>
-        <SignAgreementScreens versionId={agreement.versionId} actions={actions} />
+        <SignAgreementScreens
+          versionId={agreement.versionId}
+          actions={actions}
+        />
       </MultiModal>
     </LayoutGutter>
   )

--- a/src/components/Garden/Agreement/Agreement.js
+++ b/src/components/Garden/Agreement/Agreement.js
@@ -50,7 +50,7 @@ function Agreement() {
       <MultiModal visible={signModalVisible} onClose={handleHideModal}>
         <SignAgreementScreens
           versionId={agreement.versionId}
-          actions={actions}
+          agreementActions={actions.agreementActions}
         />
       </MultiModal>
     </LayoutGutter>

--- a/src/components/Garden/DecisionDetail/DecisionDetail.js
+++ b/src/components/Garden/DecisionDetail/DecisionDetail.js
@@ -324,9 +324,23 @@ function DecisionDetail({ proposal, actions }) {
           />
         )}
         {modalMode === 'settle' && (
-          <SettleProposalScreens proposal={proposal} />
+          <SettleProposalScreens
+            agreementActions={{
+              settleAction: actions.settleAction,
+            }}
+            proposal={proposal}
+          />
         )}
-        {modalMode === 'dispute' && <RaiseDisputeScreens proposal={proposal} />}
+        {modalMode === 'dispute' && (
+          <RaiseDisputeScreens
+            agreementActions={{
+              getAllowance: actions.getAllowance,
+              approveTokenAmount: actions.approveTokenAmount,
+              disputeAction: actions.disputeAction,
+            }}
+            proposal={proposal}
+          />
+        )}
       </MultiModal>
     </div>
   )

--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -32,7 +32,6 @@ const Home = React.memo(function Home() {
     proposals,
     proposalsFetchedCount,
   } = useGardenLogic()
-
   const history = useHistory()
   const { account } = useWallet()
 
@@ -216,9 +215,9 @@ const Home = React.memo(function Home() {
               <CreateProposalScreens onComplete={handleProposalCreated} />
             )}
             {(modalMode === 'wrap' || modalMode === 'unwrap') && (
-              <WrapTokenScreens mode={modalMode} />
+              <WrapTokenScreens mode={modalMode} hookedTokenManagerActions={actions.hookedTokenManagerActions} />
             )}
-            {modalMode === 'claim' && <ClaimRewardsScreens />}
+            {modalMode === 'claim' && <ClaimRewardsScreens unipoolActions={actions.unipoolActions} />}
           </MultiModal>
         </div>
       )}

--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -215,9 +215,14 @@ const Home = React.memo(function Home() {
               <CreateProposalScreens onComplete={handleProposalCreated} />
             )}
             {(modalMode === 'wrap' || modalMode === 'unwrap') && (
-              <WrapTokenScreens mode={modalMode} hookedTokenManagerActions={actions.hookedTokenManagerActions} />
+              <WrapTokenScreens
+                mode={modalMode}
+                hookedTokenManagerActions={actions.hookedTokenManagerActions}
+              />
             )}
-            {modalMode === 'claim' && <ClaimRewardsScreens unipoolActions={actions.unipoolActions} />}
+            {modalMode === 'claim' && (
+              <ClaimRewardsScreens unipoolActions={actions.unipoolActions} />
+            )}
           </MultiModal>
         </div>
       )}

--- a/src/components/Garden/ModalFlows/ClaimRewardsScreens/ClaimRewardsScreens.js
+++ b/src/components/Garden/ModalFlows/ClaimRewardsScreens/ClaimRewardsScreens.js
@@ -2,11 +2,8 @@ import React, { useCallback, useMemo, useState } from 'react'
 import ClaimRewards from './ClaimRewards'
 import ModalFlowBase from '../ModalFlowBase'
 
-import useActions from '@hooks/useActions'
-
-function ClaimRewardsScreens() {
+function ClaimRewardsScreens({ unipoolActions }) {
   const [transactions, setTransactions] = useState([])
-  const { unipoolActions } = useActions()
 
   const getTransactions = useCallback(
     async onComplete => {

--- a/src/components/Garden/ModalFlows/ExecuteProposalScreens/ExecuteProposalScreens.js
+++ b/src/components/Garden/ModalFlows/ExecuteProposalScreens/ExecuteProposalScreens.js
@@ -2,11 +2,8 @@ import React, { useMemo, useState, useCallback } from 'react'
 import ModalFlowBase from '../ModalFlowBase'
 import ExecuteProposal from './ExecuteProposal'
 
-import useActions from '@hooks/useActions'
-
-function ExecuteProposalScreens({ proposal }) {
+function ExecuteProposalScreens({ proposal, convictionActions }) {
   const [transactions, setTransactions] = useState([])
-  const { convictionActions } = useActions()
 
   const { id: proposalId } = proposal
 

--- a/src/components/Garden/ModalFlows/RaiseDisputeScreens/RaiseDisputeScreens.js
+++ b/src/components/Garden/ModalFlows/RaiseDisputeScreens/RaiseDisputeScreens.js
@@ -3,18 +3,16 @@ import PropTypes from 'prop-types'
 import ModalFlowBase from '../ModalFlowBase'
 import RaiseDisputeRequirements from './RaiseDisputeRequirements'
 
-import useActions from '@hooks/useActions'
 import { useCelesteSynced } from '@hooks/useCeleste'
 import { useDisputeFees } from '@hooks/useDispute'
 import BigNumber from '@lib/bigNumber'
 
 const ZERO_BN = new BigNumber('0')
 
-function RaiseDisputeScreens({ proposal }) {
+function RaiseDisputeScreens({ proposal, agreementActions }) {
   const [transactions, setTransactions] = useState([])
   const [celesteSynced, celesteSyncLoading] = useCelesteSynced()
   const disputeFees = useDisputeFees()
-  const { agreementActions } = useActions()
 
   const temporatyTrx = useRef([])
 

--- a/src/components/Garden/ModalFlows/RemoveProposalScreens/RemoveProposalScreens.js
+++ b/src/components/Garden/ModalFlows/RemoveProposalScreens/RemoveProposalScreens.js
@@ -2,11 +2,8 @@ import React, { useMemo, useState, useCallback } from 'react'
 import ModalFlowBase from '../ModalFlowBase'
 import RemoveProposal from './RemoveProposal'
 
-import useActions from '@hooks/useActions'
-
-function RemoveProposalScreens({ proposal, mode }) {
+function RemoveProposalScreens({ proposal, mode, convictionActions }) {
   const [transactions, setTransactions] = useState([])
-  const { convictionActions } = useActions()
 
   const { id: proposalId } = proposal
 

--- a/src/components/Garden/ModalFlows/SettleProposalScreens/SettleProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SettleProposalScreens/SettleProposalScreens.js
@@ -2,14 +2,12 @@ import React, { useState, useCallback, useMemo } from 'react'
 import { addressesEqual } from '@1hive/1hive-ui'
 import ModalFlowBase from '../ModalFlowBase'
 import SettlementDetails from './SettlementDetails'
-import useActions from '@hooks/useActions'
 import { useWallet } from '@providers/Wallet'
 
-function SettleProposalScreens({ proposal }) {
+function SettleProposalScreens({ proposal, agreementActions }) {
   const [transactions, setTransactions] = useState([])
 
   const { account } = useWallet()
-  const { agreementActions } = useActions()
 
   const isChallenger = addressesEqual(account, proposal.challenger)
 

--- a/src/components/Garden/ModalFlows/SignAgreementScreens/SignAgreementScreens.js
+++ b/src/components/Garden/ModalFlows/SignAgreementScreens/SignAgreementScreens.js
@@ -4,12 +4,11 @@ import { useHistory } from 'react-router'
 import { Button } from '@1hive/1hive-ui'
 import ModalFlowBase from '../ModalFlowBase'
 import SignOverview from './SignOverview'
-import useActions from '@hooks/useActions'
 
 import { buildGardenPath } from '@utils/routing-utils'
 
-function SignAgreementScreens({ versionId }) {
-  const actions = useActions()
+function SignAgreementScreens({ versionId, actions }) {
+  const { agreementActions } = actions
   const [transactions, setTransactions] = useState([])
 
   const history = useHistory()
@@ -32,7 +31,7 @@ function SignAgreementScreens({ versionId }) {
 
   const getTransactions = useCallback(
     async onComplete => {
-      await actions.agreementActions.signAgreement({ versionId }, intent => {
+      await agreementActions.signAgreement({ versionId }, intent => {
         setTransactions(intent.transactions)
         onComplete()
       })

--- a/src/components/Garden/ModalFlows/SignAgreementScreens/SignAgreementScreens.js
+++ b/src/components/Garden/ModalFlows/SignAgreementScreens/SignAgreementScreens.js
@@ -7,8 +7,7 @@ import SignOverview from './SignOverview'
 
 import { buildGardenPath } from '@utils/routing-utils'
 
-function SignAgreementScreens({ versionId, actions }) {
-  const { agreementActions } = actions
+function SignAgreementScreens({ versionId, agreementActions }) {
   const [transactions, setTransactions] = useState([])
 
   const history = useHistory()
@@ -36,7 +35,7 @@ function SignAgreementScreens({ versionId, actions }) {
         onComplete()
       })
     },
-    [actions, versionId]
+    [agreementActions, versionId]
   )
 
   const screens = useMemo(

--- a/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
+++ b/src/components/Garden/ModalFlows/SupportProposal/SupportProposalScreens.js
@@ -3,11 +3,8 @@ import ModalFlowBase from '../ModalFlowBase'
 import ChangeSupport from './ChangeSupport'
 import SupportProposal from './SupportProposal'
 
-import useActions from '@hooks/useActions'
-
-function SupportProposalScreens({ proposal, mode }) {
+function SupportProposalScreens({ proposal, mode, convictionActions }) {
   const [transactions, setTransactions] = useState([])
-  const { convictionActions } = useActions()
 
   const { id: proposalId } = proposal
 

--- a/src/components/Garden/ModalFlows/WrapTokenScreens/WrapTokenScreens.js
+++ b/src/components/Garden/ModalFlows/WrapTokenScreens/WrapTokenScreens.js
@@ -3,16 +3,14 @@ import ModalFlowBase from '../ModalFlowBase'
 import WrapUnwrap from './WrapUnwrap'
 
 import { useGardenState } from '@providers/GardenState'
-import useActions from '@hooks/useActions'
 
 import BigNumber from '@lib/bigNumber'
 
 const ZERO_BN = new BigNumber(0)
 
-function WrapTokenScreens({ mode }) {
+function WrapTokenScreens({ mode, hookedTokenManagerActions }) {
   const [transactions, setTransactions] = useState([])
   const { token, wrappableToken } = useGardenState()
-  const { hookedTokenManagerActions } = useActions()
 
   const temporatyTrx = useRef([])
 

--- a/src/components/Garden/ProposalDetail/ProposalDetail.js
+++ b/src/components/Garden/ProposalDetail/ProposalDetail.js
@@ -464,14 +464,14 @@ function ProposalDetail({
             mode={modalMode}
             convictionActions={{
               stakeToProposal: actions.stakeToProposal,
-              withdrawFromProposal: actions.withdrawFromProposal
+              withdrawFromProposal: actions.withdrawFromProposal,
             }}
           />
         )}
         {modalMode === 'remove' && (
           <RemoveProposalScreens
             convictionActions={{
-              cancelProposal: actions.cancelProposal
+              cancelProposal: actions.cancelProposal,
             }}
             proposal={proposal}
           />
@@ -479,7 +479,7 @@ function ProposalDetail({
         {modalMode === 'execute' && (
           <ExecuteProposalScreens
             convictionActions={{
-              executeProposal: actions.executeProposal
+              executeProposal: actions.executeProposal,
             }}
             proposal={proposal}
           />

--- a/src/components/Garden/ProposalDetail/ProposalDetail.js
+++ b/src/components/Garden/ProposalDetail/ProposalDetail.js
@@ -441,17 +441,48 @@ function ProposalDetail({
           />
         )}
         {modalMode === 'settle' && (
-          <SettleProposalScreens proposal={proposal} />
+          <SettleProposalScreens
+            agreementActions={{
+              settleAction: actions.settleAction,
+            }}
+            proposal={proposal}
+          />
         )}
-        {modalMode === 'dispute' && <RaiseDisputeScreens proposal={proposal} />}
+        {modalMode === 'dispute' && (
+          <RaiseDisputeScreens
+            agreementActions={{
+              getAllowance: actions.getAllowance,
+              approveTokenAmount: actions.approveTokenAmount,
+              disputeAction: actions.disputeAction,
+            }}
+            proposal={proposal}
+          />
+        )}
         {(modalMode === 'support' || modalMode === 'update') && (
-          <SupportProposalScreens proposal={proposal} mode={modalMode} />
+          <SupportProposalScreens
+            proposal={proposal}
+            mode={modalMode}
+            convictionActions={{
+              stakeToProposal: actions.stakeToProposal,
+              withdrawFromProposal: actions.withdrawFromProposal
+            }}
+          />
         )}
         {modalMode === 'remove' && (
-          <RemoveProposalScreens proposal={proposal} />
+          <RemoveProposalScreens
+            convictionActions={{
+              cancelProposal: actions.cancelProposal
+            }}
+            proposal={proposal}
+          />
         )}
         {modalMode === 'execute' && (
-          <ExecuteProposalScreens proposal={proposal} />
+          <ExecuteProposalScreens
+            convictionActions={{
+              executeProposal: actions.executeProposal
+            }}
+            proposal={proposal}
+          />
         )}
       </MultiModal>
     </div>


### PR DESCRIPTION
We worked on this issue with @juliangnr90
We removed useActions from 8 screens.
On each screen we receive only the necessary actions for the screen through props.

The only one we didn't remove is createProposalScreen because this is called from Home and Footer, with Home it's ok because it's already calling useActions, the problem is the footer component, which is called from MainView component and we are not sure which is the best way to call actions from that component.

We tested it for:
RaiseDisputeScreens
RemoveProposalScreens 
SignAgreementScreens
SupportProposalScreens
WrapTokenScreens

We will be able to test these in the next 48 hours I think, we left a proposal challenged and a proposal supported  in the test dao.
ExecuteProposalScreens
SettleProposalScreens

We don't know about ClaimRewardsScreens