### PR TITLE
Support different request token

### DIFF
--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -25,13 +25,15 @@ const Home = React.memo(function Home() {
   const {
     actions,
     commonPool,
-    config,
     errors,
     filters,
     loading,
-    mainToken,
+    priceToken,
     proposals,
     proposalsFetchedCount,
+    totalActiveTokens,
+    totalSupply,
+    totalWrappedSupply,
   } = useGardenLogic()
 
   const history = useHistory()
@@ -147,9 +149,10 @@ const Home = React.memo(function Home() {
                     commonPool={commonPool}
                     onRequestUpdatePriceOracle={handleUpdatePriceOracle}
                     onExecuteIssuance={actions.issuanceActions.executeIssuance}
-                    token={mainToken.data}
-                    totalActiveTokens={config.conviction.totalStaked}
-                    totalSupply={mainToken.totalSupply}
+                    priceToken={priceToken}
+                    totalActiveTokens={totalActiveTokens}
+                    totalSupply={totalSupply}
+                    totalWrappedSupply={totalWrappedSupply}
                   />
                 )}
                 <div

--- a/src/components/Garden/Metrics.js
+++ b/src/components/Garden/Metrics.js
@@ -204,7 +204,7 @@ function Metric({ label, value, symbol, color, helptip }) {
       </div>
       <span
         css={`
-          ${textStyle('title2')};
+          ${textStyle('title3')};
           color: ${color || theme.content};
         `}
       >
@@ -294,7 +294,7 @@ function TokenPrice({
       >
         <p
           css={`
-            ${textStyle('title2')};
+            ${textStyle('title4')};
             margin-bottom: ${0.5 * GU}px;
           `}
         >
@@ -302,7 +302,7 @@ function TokenPrice({
           {oracleMode && (
             <span
               css={`
-                ${textStyle('body3')}
+                ${textStyle('body4')}
               `}
             >
               (Oracle)

--- a/src/components/Garden/Metrics.js
+++ b/src/components/Garden/Metrics.js
@@ -22,9 +22,10 @@ const Metrics = React.memo(function Metrics({
   commonPool,
   onExecuteIssuance,
   onRequestUpdatePriceOracle,
-  token,
+  priceToken,
   totalActiveTokens,
   totalSupply,
+  totalWrappedSupply,
 }) {
   const currency = {
     name: 'USD',
@@ -43,13 +44,13 @@ const Metrics = React.memo(function Metrics({
           onExecuteIssuance={onExecuteIssuance}
           onRequestUpdatePriceOracle={onRequestUpdatePriceOracle}
           currency={currency}
-          token={token}
+          token={priceToken}
         />
         <div>
           <TokenBalance
             label="Common Pool"
-            value={commonPool}
-            token={token}
+            value={commonPool.value}
+            token={commonPool.token}
             currency={currency}
             helptip="common-pool"
           />
@@ -57,17 +58,28 @@ const Metrics = React.memo(function Metrics({
         <div>
           <TokenBalance
             label="Total Supply"
-            value={totalSupply}
-            token={token}
+            value={totalSupply.value}
+            token={totalSupply.token}
             currency={currency}
             helptip="total-supply"
           />
         </div>
+        {totalWrappedSupply && (
+          <div>
+            <TokenBalance
+              label="Total Wrapped Supply"
+              value={totalWrappedSupply.value}
+              token={totalWrappedSupply.token}
+              currency={currency}
+              helptip="total-wrapped-supply"
+            />
+          </div>
+        )}
         <div>
           <TokenBalance
             label="Total Support"
-            value={totalActiveTokens}
-            token={token}
+            value={totalActiveTokens.value}
+            token={totalActiveTokens.token}
             currency={currency}
             helptip="total-support"
           />
@@ -122,7 +134,7 @@ function PriceSection({
   )
 }
 
-function Metric({ label, value, color, helptip }) {
+function Metric({ label, value, symbol, color, helptip }) {
   const theme = useTheme()
 
   return (
@@ -149,7 +161,14 @@ function Metric({ label, value, color, helptip }) {
           color: ${color || theme.content};
         `}
       >
-        {value}
+        {value}{' '}
+        <span
+          css={`
+            ${textStyle('body3')}
+          `}
+        >
+          {symbol}
+        </span>
       </span>
     </>
   )
@@ -165,6 +184,7 @@ function TokenBalance({ label, token, value, currency, helptip }) {
       <Metric
         label={label}
         value={formatTokenAmount(value, token.decimals)}
+        symbol={token.symbol}
         helptip={helptip}
       />
       <div
@@ -216,7 +236,7 @@ function TokenPrice({
   return (
     <div
       css={`
-        width: ${30 * GU}px;
+        width: ${25 * GU}px;
       `}
     >
       <div

--- a/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
+++ b/src/components/Garden/ModalFlows/CreateProposalScreens/AddProposal.js
@@ -19,7 +19,7 @@ import { useMultiModal } from '@components/MultiModal/MultiModalProvider'
 import { usePriceOracle } from '@hooks/usePriceOracle'
 import BigNumber from '@lib/bigNumber'
 import { toDecimals } from '@utils/math-utils'
-import { formatTokenAmount } from '@utils/token-utils'
+import { formatTokenAmount, isStableToken } from '@utils/token-utils'
 import { calculateThreshold, getMaxConviction } from '@lib/conviction'
 
 import { useHistory } from 'react-router-dom'
@@ -339,6 +339,8 @@ function RequestedAmount({
   const theme = useTheme()
   const { stable, value } = amount
 
+  const isRequestTokenStable = isStableToken(requestToken)
+
   return (
     <>
       <Field label="Requested Amount" onFocus={onFocus} onBlur={onBlur}>
@@ -363,34 +365,36 @@ function RequestedAmount({
           adornmentPosition="end"
           adornmentSettings={{ padding: 1 }}
         />
-        <div
-          css={`
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            color: ${theme.contentSecondary};
-            margin-top: ${0.75 * GU}px;
-          `}
-        >
-          {stable ? (
-            <ConvertedAmount
-              amount={convertedAmount}
-              loading={loadingAmount}
-              requestToken={requestToken}
-            />
-          ) : (
-            <div />
-          )}
+        {!isRequestTokenStable && (
           <div
             css={`
               display: flex;
               align-items: center;
+              justify-content: space-between;
+              color: ${theme.contentSecondary};
+              margin-top: ${0.75 * GU}px;
             `}
           >
-            <Checkbox checked={stable} onChange={onIsStableChange} />
-            <span>Stable amount ({stableToken.symbol})</span>
+            {stable ? (
+              <ConvertedAmount
+                amount={convertedAmount}
+                loading={loadingAmount}
+                requestToken={requestToken}
+              />
+            ) : (
+              <div />
+            )}
+            <div
+              css={`
+                display: flex;
+                align-items: center;
+              `}
+            >
+              <Checkbox checked={stable} onChange={onIsStableChange} />
+              <span>Stable amount ({stableToken.symbol})</span>
+            </div>
           </div>
-        </div>
+        )}
       </Field>
       <Info
         css={`
@@ -398,9 +402,10 @@ function RequestedAmount({
         `}
       >
         The larger the requested amount, the more support required for the
-        proposal to pass. If you specify the proposal amount in {` `}
-        {stableToken.symbol} it will be converted to {requestToken.symbol}{' '}
-        if/when it is passed.{' '}
+        proposal to pass.{' '}
+        {isRequestTokenStable
+          ? ''
+          : `If you specify the proposal amount in ${stableToken.symbol} it will be converted to ${requestToken.symbol} if/when it is passed.`}{' '}
         {neededThreshold
           ? `The conviction
         required in order for the proposal to pass with the requested amount is

--- a/src/components/HelpTip.js
+++ b/src/components/HelpTip.js
@@ -69,10 +69,10 @@ const KNOWN_HELP_DESCRIPTIONS = {
     </>,
   ],
   'total-wrapped-supply': [
-    'Total Wrapped Supply',
+    'Wrapped Supply',
     <>
-      The <strong>Wrapped Supply</strong> is the amount of wrapped tokens
-      in circulation.
+      The <strong>Wrapped Supply</strong> is the amount of wrapped tokens in
+      circulation.
     </>,
   ],
   'total-support': [

--- a/src/components/HelpTip.js
+++ b/src/components/HelpTip.js
@@ -68,6 +68,13 @@ const KNOWN_HELP_DESCRIPTIONS = {
       circulation, including the common pool.
     </>,
   ],
+  'total-wrapped-supply': [
+    'Total Wrapped Supply',
+    <>
+      The <strong>Total Wrapped Supply</strong> is the the total amount of
+      wrapped tokens in circulation.
+    </>,
+  ],
   'total-support': [
     'Total Support',
     <>

--- a/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings/index.js
+++ b/src/components/Onboarding/Screens/Apps/ConvictionVotingSettings/index.js
@@ -137,8 +137,8 @@ function ConvictionVotingSettings() {
   )
 
   const handleRequestTokenChange = useCallback(
-    value => {
-      updateField(['requestToken', value])
+    event => {
+      updateField(['requestToken', event.target.value])
     },
     [updateField]
   )

--- a/src/logic/garden-logic.js
+++ b/src/logic/garden-logic.js
@@ -36,7 +36,7 @@ export default function useGardenLogic() {
       value: config?.conviction.totalStaked,
       token: config?.conviction.stakeToken,
     },
-    // mainToken: BYOT ? wrappableToken : token
+    // For BYOT gardens, mainToken will be `wrappableToken`, for native gardens will be `token`
     totalSupply: { value: mainToken.totalSupply, token: mainToken.data },
     // For BYOT we will also display the total suppply of the wrapped token
     totalWrappedSupply: wrappableToken

--- a/src/logic/garden-logic.js
+++ b/src/logic/garden-logic.js
@@ -3,8 +3,16 @@ import { useGardenState } from '@providers/GardenState'
 import { useProposals } from '@hooks/useProposals'
 
 // Handles the main logic of the app.
-export default function useAppLogic() {
-  const { commonPool, config, errors, loading, mainToken } = useGardenState()
+export default function useGardenLogic() {
+  const {
+    commonPool,
+    config,
+    errors,
+    loading,
+    mainToken,
+    token,
+    wrappableToken,
+  } = useGardenState()
 
   const actions = useActions()
   const [
@@ -16,13 +24,23 @@ export default function useAppLogic() {
 
   return {
     actions,
-    commonPool,
+    commonPool: { value: commonPool, token: config?.conviction.requestToken },
     config,
     errors,
     filters,
     loading: loading || !blockHasLoaded,
-    mainToken,
+    priceToken: mainToken.data,
     proposals,
     proposalsFetchedCount,
+    totalActiveTokens: {
+      value: config?.conviction.totalStaked,
+      token: config?.conviction.stakeToken,
+    },
+    // mainToken: BYOT ? wrappableToken : token
+    totalSupply: { value: mainToken.totalSupply, token: mainToken.data },
+    // For BYOT we will also display the total suppply of the wrapped token
+    totalWrappedSupply: wrappableToken
+      ? { value: token.totalSupply, token: token.data }
+      : null,
   }
 }

--- a/src/providers/GardenState.js
+++ b/src/providers/GardenState.js
@@ -25,7 +25,7 @@ function GardenStateProvider({ children }) {
   const [tokens, tokensLoading] = useTokens(config)
   const commonPool = useCommonPool(
     config?.conviction.fundsManager,
-    (tokens.wrappableToken || tokens.token).data
+    config?.conviction.requestToken
   )
   const effectiveSupply = useEffectiveSupply(tokens.token.totalSupply, config)
 

--- a/src/utils/token-utils.js
+++ b/src/utils/token-utils.js
@@ -4,6 +4,8 @@ import defaultTokenSvg from '@assets/defaultTokenLogo.svg'
 import honeyIconSvg from '@assets/honey.svg'
 import stableTokenSvg from '@assets/stable-token.svg'
 
+const LOCAL_STABLE_ICONS = ['DAI', 'XDAI', 'WXDAI', 'USDC', 'USDT', 'LUSD']
+
 const LOCAL_TOKEN_ICONS = new Map([
   ['HNY', honeyIconSvg],
   ['HNYT', honeyIconSvg],
@@ -25,6 +27,10 @@ export function getGardenTokenIcon(garden, token) {
 
   // Look up in the local mapping
   return getLocalTokenIconBySymbol(token.symbol)
+}
+
+export function isStableToken(token) {
+  return LOCAL_STABLE_ICONS.includes(token.symbol)
 }
 
 export function getLocalTokenIconBySymbol(symbol) {


### PR DESCRIPTION
closes https://github.com/1Hive/honey-pot/issues/656

- Updated common pool token to be request token
- Rearranges the Metrics component:
![Screen Shot 2021-11-09 at 00 21 59](https://user-images.githubusercontent.com/22663232/140856342-ad9e542d-7d82-4422-b9d7-e6b193584aa9.png)
![Screen Shot 2021-11-09 at 00 22 25](https://user-images.githubusercontent.com/22663232/140856349-5414bd71-5c7b-4497-843d-be40d3e798b1.png)
It now shows wrapped supply for BYOT gardens

- Create proposal: Removed the option to request amount in stable value if request token is already a stable token.

