### PR TITLE
Loader refactor

### DIFF
--- a/src/components/Garden/Agreement/Agreement.js
+++ b/src/components/Garden/Agreement/Agreement.js
@@ -4,11 +4,11 @@ import AgreementBindingActions from './AgreementBindingActions'
 import AgreementDetails from './AgreementDetails'
 import AgreementDocument from './AgreementDocument'
 import AgreementHeader from './AgreementHeader'
+import { GardenLoader } from '@components/Loader'
 import LayoutGutter from '../Layout/LayoutGutter'
 import LayoutLimiter from '../Layout/LayoutLimiter'
 import LayoutBox from '../Layout/LayoutBox'
 import LayoutColumns from '../Layout/LayoutColumns'
-import Loader from '@components/Loader'
 import MultiModal from '@components/MultiModal/MultiModal'
 import SignAgreementScreens from '../ModalFlows/SignAgreementScreens/SignAgreementScreens'
 import { useAgreement } from '@hooks/useAgreement'
@@ -31,7 +31,7 @@ function Agreement() {
   }, [])
 
   if (loading) {
-    return <Loader />
+    return <GardenLoader />
   }
 
   return (

--- a/src/components/Garden/DecisionLoader.js
+++ b/src/components/Garden/DecisionLoader.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import DecisionDetail from './DecisionDetail/DecisionDetail'
-import Loader from '../Loader'
+import { GardenLoader } from '../Loader'
 import useProposalLogic from '../../logic/proposal-logic'
 
 function DecisionLoader({ match }) {
@@ -11,7 +11,7 @@ function DecisionLoader({ match }) {
   } = useProposalLogic(match)
 
   if (!proposal || loading) {
-    return <Loader />
+    return <GardenLoader />
   }
 
   return (

--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -6,7 +6,7 @@ import ClaimRewardsScreens from './ModalFlows/ClaimRewardsScreens/ClaimRewardsSc
 import CreateProposalScreens from './ModalFlows/CreateProposalScreens/CreateProposalScreens'
 import PriceOracleScreens from './ModalFlows/PriceOracleScreens/PriceOracleScreens'
 import Filters from './Filters/Filters'
-import Loader from '../Loader'
+import { GardenLoader } from '../Loader'
 import Metrics from './Metrics'
 import MultiModal from '../MultiModal/MultiModal'
 import NetworkErrorModal from '../NetworkErrorModal'
@@ -97,14 +97,15 @@ const Home = React.memo(function Home() {
   }, [account, handleRequestNewProposal, history])
 
   // TODO: Refactor components positioning with a grid layout
+  const megaLoader = loading || true
   return (
     <div
       css={`
         height: 100%;
       `}
     >
-      {loading ? (
-        <Loader />
+      {megaLoader ? (
+        <GardenLoader />
       ) : (
         <>
           <div

--- a/src/components/Garden/Home.js
+++ b/src/components/Garden/Home.js
@@ -97,14 +97,14 @@ const Home = React.memo(function Home() {
   }, [account, handleRequestNewProposal, history])
 
   // TODO: Refactor components positioning with a grid layout
-  const megaLoader = loading || true
+
   return (
     <div
       css={`
         height: 100%;
       `}
     >
-      {megaLoader ? (
+      {loading ? (
         <GardenLoader />
       ) : (
         <>

--- a/src/components/Garden/ProposalLoader.js
+++ b/src/components/Garden/ProposalLoader.js
@@ -1,6 +1,6 @@
 import React from 'react'
+import { GardenLoader } from '../Loader'
 import ProposalDetail from './ProposalDetail/ProposalDetail'
-import Loader from '../Loader'
 import useProposalLogic from '../../logic/proposal-logic'
 import { useProposalWithThreshold } from '@hooks/useProposals'
 import { ProposalTypes } from '@/types'
@@ -17,7 +17,7 @@ function ProposalLoader({ match }) {
   } = useProposalLogic(match)
 
   if (!proposal || loading) {
-    return <Loader />
+    return <GardenLoader />
   }
 
   return proposal.type === ProposalTypes.Proposal ? (
@@ -45,7 +45,7 @@ function WithThreshold({ proposal, ...props }) {
   const [proposalWithThreshold, loading] = useProposalWithThreshold(proposal)
 
   if (loading) {
-    return <Loader />
+    return <GardenLoader />
   }
 
   return <ProposalDetail proposal={proposalWithThreshold} {...props} />

--- a/src/components/Garden/Stake/StakeManagement.js
+++ b/src/components/Garden/Stake/StakeManagement.js
@@ -2,10 +2,10 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
 import { Header } from '@1hive/1hive-ui'
 import EmptyState from './EmptyState'
+import { GardenLoader } from '@components/Loader'
 import LayoutColumns from '../Layout/LayoutColumns'
 import LayoutGutter from '../Layout/LayoutGutter'
 import LayoutLimiter from '../Layout/LayoutLimiter'
-import Loader from '@components/Loader'
 import MultiModal from '@components/MultiModal/MultiModal'
 import SideBar from './SideBar'
 import StakeScreens from '../ModalFlows/StakeScreens/StakeScreens'
@@ -50,7 +50,7 @@ const StakeManagement = React.memo(function StakeManagement() {
   return (
     <>
       {loading ? (
-        <Loader />
+        <GardenLoader />
       ) : (
         <LayoutGutter>
           <LayoutLimiter>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -12,7 +12,6 @@ function CustomLayout({ children, paddingBottom = 0 }) {
       css={`
         ${vw < BREAKPOINTS.large && `width: auto;`}
         min-width: auto;
-        height: 100%;
       `}
     >
       {children}

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -1,12 +1,11 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { useRouteMatch } from 'react-router'
 import Lottie from 'react-lottie-player'
 import styled from 'styled-components'
 
 import beeAnimation from '@assets/lotties/bee-animation.json'
 import gardensLoader from '@assets/lotties/gardens-loader.json'
-import { HIVE_GARDEN_ADDRESSES } from '@/constants'
-import { addressesEqual } from '@/utils/web3-utils'
+import { is1HiveGarden } from '@/utils/garden-utils'
 
 const Wrapper = styled.div`
   pointer-events: none;
@@ -17,29 +16,35 @@ const Wrapper = styled.div`
   width: 100%;
 `
 
+export function GardenLoader() {
+  return (
+    <div
+      css={`
+        position: absolute;
+        top: 45%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        height: 100%;
+      `}
+    >
+      <Loader />
+    </div>
+  )
+}
+
 function Loader() {
   const match = useRouteMatch('/garden/:daoId')
-
-  const is1HiveGarden = useMemo(() => {
-    if (match) {
-      const gardenAddress = match.params.daoId
-      return HIVE_GARDEN_ADDRESSES.reduce((isHive, current) => {
-        return isHive || addressesEqual(gardenAddress, current)
-      }, false)
-    }
-
-    return false
-  }, [match])
+  const is1Hive = is1HiveGarden(match?.params.daoId)
 
   return (
     <Wrapper>
       <Lottie
-        animationData={is1HiveGarden ? beeAnimation : gardensLoader}
+        animationData={is1Hive ? beeAnimation : gardensLoader}
         play
         loop
         style={{
-          height: is1HiveGarden ? 100 : 150,
-          width: is1HiveGarden ? 100 : 150,
+          height: is1Hive ? 100 : 150,
+          width: is1Hive ? 100 : 150,
         }}
       />
     </Wrapper>

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,11 +18,6 @@ export const PCT_BASE = bigNum(1)
 
 export const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
-export const HIVE_GARDEN_ADDRESSES = [
-  '0x8ccbeab14b5ac4a431fffc39f4bec4089020a155',
-  '0x7777cd7c9c6d3537244871ac8e73b3cb9710d45a',
-]
-
 export const VOTE_ABSENT = 'VOTE_ABSENT'
 export const VOTE_YEA = 'VOTE_YEA'
 export const VOTE_NAY = 'VOTE_NAY'

--- a/src/networks.js
+++ b/src/networks.js
@@ -14,6 +14,8 @@ const networks = {
     ensRegistry: '0x98df287b6c145399aaa709692c8d308357bc085d',
     name: 'Rinkeby',
     type: 'rinkeby',
+
+    hiveGarden: '0x7777cd7c9c6d3537244871ac8e73b3cb9710d45a',
     arbitrator: '0x35e7433141D5f7f2EB7081186f5284dCDD2ccacE',
     disputeManager: '0xc1f1c30878de30fd3ac3db7eacdd33a70c7110bd',
     template: '0xF8A030177865356E2Be8fb5F95a19962E6b57E3e',
@@ -40,6 +42,8 @@ const networks = {
     name: 'xDai',
     type: 'xdai',
     defaultEthNode: XDAI_ETH_NODE,
+
+    hiveGarden: '0x8ccbeab14b5ac4a431fffc39f4bec4089020a155',
     arbitrator: '0x44E4fCFed14E1285c9e0F6eae77D5fDd0F196f85',
     disputeManager: '0xec7904e20b69f60966d6c6b9dc534355614dd922',
     template: '0x9B770712603d66Faa8F048EEf4C0Afd2FA7F0844',

--- a/src/utils/garden-utils.js
+++ b/src/utils/garden-utils.js
@@ -1,3 +1,4 @@
+import { getNetwork } from '@/networks'
 import { addressesEqual } from './web3-utils'
 
 const DEFAULT_FORUM_URL = 'https://forum.1hive.org/'
@@ -50,4 +51,13 @@ export function mergeGardenMetadata(garden, gardensMetadata, chainId) {
     token,
     wrappableToken,
   }
+}
+
+export function is1HiveGarden(gardenAddress) {
+  if (!gardenAddress) {
+    return false
+  }
+
+  const network = getNetwork()
+  return addressesEqual(gardenAddress, network.hiveGarden)
 }


### PR DESCRIPTION
- Removes Layout height
- Adds GardenLoader to be used only by Garden Components. We can´t have a good solution for all loading screens when they expect different dimensions from the parent. 
- Moved hive addresses to networks file and moved is1HiveGarden logic to garden-utils